### PR TITLE
chore: security enhancement

### DIFF
--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/admin.ts
@@ -4,8 +4,8 @@ import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/globa
 import { Router } from 'express';
 import { FACEBOOK_ADMIN_STRATEGY_NAME, FacebookAuthOptions, Profile } from './types';
 import { PassportStrategy } from '../../core/passport/Strategy';
-import { validateAdminCallback } from "../../core/validate-callback";
-import { passportAuthRoutesBuilder } from "../../core/passport/utils/auth-routes-builder";
+import { validateAdminCallback } from '../../core/validate-callback';
+import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
 
 export class FacebookAdminStrategy extends PassportStrategy(FacebookStrategy, FACEBOOK_ADMIN_STRATEGY_NAME) {
 	constructor(
@@ -48,7 +48,7 @@ export class FacebookAdminStrategy extends PassportStrategy(FacebookStrategy, FA
  */
 export function getFacebookAdminAuthRouter(facebook: FacebookAuthOptions, configModule: ConfigModule): Router {
 	return passportAuthRoutesBuilder({
-		domain: "admin",
+		domain: 'admin',
 		configModule,
 		authPath: facebook.admin.authPath ?? '/admin/auth/facebook',
 		authCallbackPath: facebook.admin.authCallbackPath ?? '/admin/auth/facebook/cb',
@@ -57,6 +57,6 @@ export function getFacebookAdminAuthRouter(facebook: FacebookAuthOptions, config
 		passportAuthenticateMiddleware: passport.authenticate(FACEBOOK_ADMIN_STRATEGY_NAME, {
 			scope: ['email'],
 			session: false,
-		})
+		}),
 	});
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/store.ts
@@ -4,8 +4,8 @@ import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/globa
 import { Strategy as FacebookStrategy } from 'passport-facebook';
 import { FACEBOOK_STORE_STRATEGY_NAME, FacebookAuthOptions, Profile } from './types';
 import { PassportStrategy } from '../../core/passport/Strategy';
-import { validateStoreCallback } from "../../core/validate-callback";
-import { passportAuthRoutesBuilder } from "../../core/passport/utils/auth-routes-builder";
+import { validateStoreCallback } from '../../core/validate-callback';
+import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
 
 export class FacebookStoreStrategy extends PassportStrategy(FacebookStrategy, FACEBOOK_STORE_STRATEGY_NAME) {
 	constructor(
@@ -37,7 +37,7 @@ export class FacebookStoreStrategy extends PassportStrategy(FacebookStrategy, FA
 				profile
 			);
 		}
-		return await validateStoreCallback(this)(profile, { strategyErrorIdentifier: "Facebook" });
+		return await validateStoreCallback(this)(profile, { strategyErrorIdentifier: 'Facebook' });
 	}
 }
 
@@ -47,9 +47,8 @@ export class FacebookStoreStrategy extends PassportStrategy(FacebookStrategy, FA
  * @param configModule
  */
 export function getFacebookStoreAuthRouter(facebook: FacebookAuthOptions, configModule: ConfigModule): Router {
-	return passportAuthRoutesBuilder(
-		{
-			domain: "store",
+	return passportAuthRoutesBuilder({
+		domain: 'store',
 		configModule,
 		authPath: facebook.store.authPath ?? '/store/auth/facebook',
 		authCallbackPath: facebook.store.authCallbackPath ?? '/store/auth/facebook/cb',
@@ -58,6 +57,6 @@ export function getFacebookStoreAuthRouter(facebook: FacebookAuthOptions, config
 		passportAuthenticateMiddleware: passport.authenticate(FACEBOOK_STORE_STRATEGY_NAME, {
 			scope: ['email'],
 			session: false,
-		})
+		}),
 	});
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/admin.ts
@@ -48,7 +48,7 @@ export class GoogleAdminStrategy extends PassportStrategy(GoogleStrategy, GOOGLE
  */
 export function getGoogleAdminAuthRouter(google: GoogleAuthOptions, configModule: ConfigModule): Router {
 	return passportAuthRoutesBuilder({
-		domain: "admin",
+		domain: 'admin',
 		configModule,
 		authPath: google.admin.authPath ?? '/admin/auth/google',
 		authCallbackPath: google.admin.authCallbackPath ?? '/admin/auth/google/cb',

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/store.ts
@@ -5,7 +5,7 @@ import { Strategy as GoogleStrategy } from 'passport-google-oauth2';
 import { PassportStrategy } from '../../core/passport/Strategy';
 import { GOOGLE_STORE_STRATEGY_NAME, GoogleAuthOptions, Profile } from './types';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
-import { validateStoreCallback } from "../../core/validate-callback";
+import { validateStoreCallback } from '../../core/validate-callback';
 
 export class GoogleStoreStrategy extends PassportStrategy(GoogleStrategy, GOOGLE_STORE_STRATEGY_NAME) {
 	constructor(
@@ -36,7 +36,7 @@ export class GoogleStoreStrategy extends PassportStrategy(GoogleStrategy, GOOGLE
 				profile
 			);
 		}
-		return await validateStoreCallback(this)(profile, { strategyErrorIdentifier: "Google" });
+		return await validateStoreCallback(this)(profile, { strategyErrorIdentifier: 'Google' });
 	}
 }
 
@@ -46,9 +46,8 @@ export class GoogleStoreStrategy extends PassportStrategy(GoogleStrategy, GOOGLE
  * @param configModule
  */
 export function getGoogleStoreAuthRouter(google: GoogleAuthOptions, configModule: ConfigModule): Router {
-	return passportAuthRoutesBuilder(
-		{
-			domain: "store",
+	return passportAuthRoutesBuilder({
+		domain: 'store',
 		configModule,
 		authPath: google.store.authPath ?? '/store/auth/google',
 		authCallbackPath: google.store.authCallbackPath ?? '/store/auth/google/cb',

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/admin.ts
@@ -4,8 +4,8 @@ import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/globa
 import { Router } from 'express';
 import { LINKEDIN_ADMIN_STRATEGY_NAME, LinkedinAuthOptions, Profile } from './types';
 import { PassportStrategy } from '../../core/passport/Strategy';
-import { validateAdminCallback } from "../../core/validate-callback";
-import { passportAuthRoutesBuilder } from "../../core/passport/utils/auth-routes-builder";
+import { validateAdminCallback } from '../../core/validate-callback';
+import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
 
 export class LinkedinAdminStrategy extends PassportStrategy(LinkedinStrategy, LINKEDIN_ADMIN_STRATEGY_NAME) {
 	constructor(
@@ -50,7 +50,7 @@ export class LinkedinAdminStrategy extends PassportStrategy(LinkedinStrategy, LI
  */
 export function getLinkedinAdminAuthRouter(linkedin: LinkedinAuthOptions, configModule: ConfigModule): Router {
 	return passportAuthRoutesBuilder({
-		domain: "admin",
+		domain: 'admin',
 		configModule,
 		authPath: linkedin.admin.authPath ?? '/admin/auth/linkedin',
 		authCallbackPath: linkedin.admin.authCallbackPath ?? '/admin/auth/linkedin/cb',

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/store.ts
@@ -4,8 +4,8 @@ import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/globa
 import { Strategy as LinkedinStrategy } from 'passport-linkedin-oauth2';
 import { PassportStrategy } from '../../core/passport/Strategy';
 import { LINKEDIN_STORE_STRATEGY_NAME, LinkedinAuthOptions, Profile } from './types';
-import { validateStoreCallback } from "../../core/validate-callback";
-import { passportAuthRoutesBuilder } from "../../core/passport/utils/auth-routes-builder";
+import { validateStoreCallback } from '../../core/validate-callback';
+import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
 
 export class LinkedinStoreStrategy extends PassportStrategy(LinkedinStrategy, LINKEDIN_STORE_STRATEGY_NAME) {
 	constructor(
@@ -38,7 +38,7 @@ export class LinkedinStoreStrategy extends PassportStrategy(LinkedinStrategy, LI
 				profile
 			);
 		}
-		return await validateStoreCallback(this)(profile, { strategyErrorIdentifier: "Linkedin" });
+		return await validateStoreCallback(this)(profile, { strategyErrorIdentifier: 'Linkedin' });
 	}
 }
 
@@ -48,9 +48,8 @@ export class LinkedinStoreStrategy extends PassportStrategy(LinkedinStrategy, LI
  * @param configModule
  */
 export function getLinkedinStoreAuthRouter(linkedin: LinkedinAuthOptions, configModule: ConfigModule): Router {
-	return passportAuthRoutesBuilder(
-		{
-			domain: "store",
+	return passportAuthRoutesBuilder({
+		domain: 'store',
 		configModule,
 		authPath: linkedin.store.authPath ?? '/store/auth/linkedin',
 		authCallbackPath: linkedin.store.authCallbackPath ?? '/store/auth/linkedin/cb',

--- a/packages/medusa-plugin-auth/src/core/passport/Strategy.ts
+++ b/packages/medusa-plugin-auth/src/core/passport/Strategy.ts
@@ -9,6 +9,8 @@ export function PassportStrategy<T extends Type<any> = any>(
 	new (...args): InstanceType<T>;
 } {
 	abstract class MixinStrategy extends Strategy {
+		AUTH_PROVIDER_NAME: string;
+
 		abstract validate(...args: any[]): any;
 
 		protected constructor(...args: any[]) {
@@ -24,6 +26,8 @@ export function PassportStrategy<T extends Type<any> = any>(
 			};
 
 			super(...args, callback);
+
+			this.AUTH_PROVIDER_NAME = name;
 
 			const passportInstance = this.getPassportInstance();
 			if (name) {

--- a/packages/medusa-plugin-auth/src/core/passport/utils/auth-routes-builder.ts
+++ b/packages/medusa-plugin-auth/src/core/passport/utils/auth-routes-builder.ts
@@ -27,7 +27,7 @@ export function passportAuthRoutesBuilder({
 	authCallbackPath,
 	failureRedirect,
 }: {
-	domain: "admin" | "store",
+	domain: 'admin' | 'store';
 	configModule: ConfigModule;
 	authPath: string;
 	passportAuthenticateMiddleware: RequestHandler<any>;

--- a/packages/medusa-plugin-auth/src/types/index.ts
+++ b/packages/medusa-plugin-auth/src/types/index.ts
@@ -5,6 +5,7 @@ import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/globa
 import { Router } from 'express';
 
 export const CUSTOMER_METADATA_KEY = 'useSocialAuth';
+export const ALLOWED_AUTH_PROVIDERS_KEY = 'allowed_providers';
 
 export const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000;
 


### PR DESCRIPTION
- allow admin auth only if it has been activated for the auth provider.
- allow customer auth after the first connection for the provider that has been used only. if another provider is used after the one used the first time, it will be rejected