### PR TITLE
Firebase documentation fix

### DIFF
--- a/docs/pages/authentication/firebase.mdx
+++ b/docs/pages/authentication/firebase.mdx
@@ -25,7 +25,6 @@ newly added plugins. To do so here are the steps
     const STORE_URL = process.env.STORE_URL || "localhost:8000"
 
     const CredentialJsonPath = process.env.FIREBASE_CREDS_JSON_PATH || ""
-    const FirebaseClientSecret = process.env.FIREBASE_CLIENT_SECRET || ""
     ```
 
     Then in your `plugins` collections, if you did not already inserted the plugin, add the following otherwise, you can


### PR DESCRIPTION
There is no Firebase client secret to configure with Firebase auth. Only service account credentials.