### PR TITLE
feat: add support for strict options

### DIFF
--- a/docs/pages/authentication/auth0.mdx
+++ b/docs/pages/authentication/auth0.mdx
@@ -35,6 +35,7 @@ newly added plugins. To do so here are the steps
     {
         resolve: "medusa-plugin-auth",
         options: {
+            // strict: "all", // or "none" or "store" or "admin"
             auth0: {
                 clientID: Auth0ClientId,
                 clientSecret: Auth0ClientSecret,
@@ -84,7 +85,7 @@ newly added plugins. To do so here are the steps
 
 ### Default behaviour
 
-The default `verifyCallback` flow looks as follow,
+The default `verifyCallback` flow looks as follow (unless the `strict` option is changed to `none` or `store` or `admin` depending on the targeted domain)
 - for the `admin`
     - if the user trying to authenticate exists
         - then we are looking in the metadata to find if the strategy identifier is present in `authProvider`.

--- a/docs/pages/authentication/azureoidc.mdx
+++ b/docs/pages/authentication/azureoidc.mdx
@@ -37,6 +37,7 @@ newly added plugins. To do so here are the steps
         resolve: "medusa-plugin-auth",
         options: {
             azure_oidc: {
+                // strict: "all", // or "none" or "store" or "admin"
                 admin: {
 					identityMetadata: AzureIdentityMetadata,
 					clientID: AzureClientId,
@@ -115,7 +116,7 @@ It has only been tested with default options. As of now only ResponseType.Code a
 
 ### Default behaviour
 
-The default `verifyCallback` flow looks as follow,
+The default `verifyCallback` flow looks as follow (unless the `strict` option is changed to `none` or `store` or `admin` depending on the targeted domain)
 - for the `admin`
     - if the user trying to authenticate exists
         - then we are looking in the metadata to find if the strategy identifier is present in `authProvider`.

--- a/docs/pages/authentication/facebook.mdx
+++ b/docs/pages/authentication/facebook.mdx
@@ -34,6 +34,7 @@ newly added plugins. To do so here are the steps
     {
         resolve: "medusa-plugin-auth",
         options: {
+            // strict: "all", // or "none" or "store" or "admin"
             facebook: {
                 clientID: FacebookClientId,
                 clientSecret: FacebookClientSecret,
@@ -90,7 +91,7 @@ newly added plugins. To do so here are the steps
 
 ### Default behaviour
 
-The default `verifyCallback` flow looks as follow,
+The default `verifyCallback` flow looks as follow (unless the `strict` option is changed to `none` or `store` or `admin` depending on the targeted domain)
 - for the `admin`
     - if the user trying to authenticate exists
         - then we are looking in the metadata to find if the strategy identifier is present in `authProvider`.

--- a/docs/pages/authentication/firebase.mdx
+++ b/docs/pages/authentication/firebase.mdx
@@ -33,6 +33,7 @@ newly added plugins. To do so here are the steps
     {
         resolve: "medusa-plugin-auth",
         options: {
+            // strict: "all", // or "none" or "store" or "admin"
             firebase: {
                 credentialJsonPath: CredentialJsonPath,
 
@@ -78,7 +79,7 @@ newly added plugins. To do so here are the steps
 
 ### Default behaviour
 
-The default `verifyCallback` flow looks as follow,
+The default `verifyCallback` flow looks as follow (unless the `strict` option is changed to `none` or `store` or `admin` depending on the targeted domain)
 - for the `admin`
     - if the user trying to authenticate exists
         - then we are looking in the metadata to find if the strategy identifier is present in `authProvider`.

--- a/docs/pages/authentication/google.mdx
+++ b/docs/pages/authentication/google.mdx
@@ -34,6 +34,7 @@ newly added plugins. To do so here are the steps
     {
         resolve: "medusa-plugin-auth",
         options: {
+            // strict: "all", // or "none" or "store" or "admin"
             google: {
                 clientID: GoogleClientId,
                 clientSecret: GoogleClientSecret,
@@ -90,7 +91,7 @@ newly added plugins. To do so here are the steps
 
 ### Default behaviour
 
-The default `verifyCallback` flow looks as follow,
+The default `verifyCallback` flow looks as follow (unless the `strict` option is changed to `none` or `store` or `admin` depending on the targeted domain)
 - for the `admin`
     - if the user trying to authenticate exists
         - then we are looking in the metadata to find if the strategy identifier is present in `authProvider`.

--- a/docs/pages/authentication/linkedin.mdx
+++ b/docs/pages/authentication/linkedin.mdx
@@ -33,6 +33,7 @@ newly added plugins. To do so here are the steps
     ```js
     {
         resolve: "medusa-plugin-auth",
+        // strict: "all", // or "none" or "store" or "admin"
         options: {
             linkedin: {
                 clientID: LinkedinClientId,
@@ -90,7 +91,7 @@ newly added plugins. To do so here are the steps
 
 ### Default behaviour
 
-The default `verifyCallback` flow looks as follow,
+The default `verifyCallback` flow looks as follow (unless the `strict` option is changed to `none` or `store` or `admin` depending on the targeted domain)
 - for the `admin`
     - if the user trying to authenticate exists
         - then we are looking in the metadata to find if the strategy identifier is present in `authProvider`.

--- a/packages/medusa-plugin-auth/src/auth-strategies/auth0/__tests__/admin/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/auth0/__tests__/admin/verify-callback.spec.ts
@@ -177,8 +177,7 @@ describe('Auth0 admin strategy verify callback', function () {
 				emails: [{ value: existsEmailWithWrongProviderKey }],
 			};
 
-			const data = await auth0AdminStrategy
-				.validate(req, accessToken, refreshToken, extraParams, profile)
+			const data = await auth0AdminStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
 			expect(data).toEqual({
 				accessToken: undefined,
 				id: 'test3',

--- a/packages/medusa-plugin-auth/src/auth-strategies/auth0/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/auth0/admin.ts
@@ -5,13 +5,14 @@ import { AUTH0_ADMIN_STRATEGY_NAME, Auth0Options, Profile, ExtraParams } from '.
 import { PassportStrategy } from '../../core/passport/Strategy';
 import { validateAdminCallback } from '../../core/validate-callback';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { AuthOptions } from '../../types';
 
 export class Auth0AdminStrategy extends PassportStrategy(Auth0Strategy, AUTH0_ADMIN_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: Auth0Options,
-		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			domain: strategyOptions.auth0Domain,
@@ -48,7 +49,7 @@ export class Auth0AdminStrategy extends PassportStrategy(Auth0Strategy, AUTH0_AD
 		const validateRes = await validateAdminCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'auth0',
-			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 		return {
 			...validateRes,

--- a/packages/medusa-plugin-auth/src/auth-strategies/auth0/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/auth0/admin.ts
@@ -11,7 +11,7 @@ export class Auth0AdminStrategy extends PassportStrategy(Auth0Strategy, AUTH0_AD
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: Auth0Options,
-		protected readonly strictOptions: { admin_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			domain: strategyOptions.auth0Domain,

--- a/packages/medusa-plugin-auth/src/auth-strategies/auth0/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/auth0/admin.ts
@@ -10,7 +10,8 @@ export class Auth0AdminStrategy extends PassportStrategy(Auth0Strategy, AUTH0_AD
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: Auth0Options
+		protected readonly strategyOptions: Auth0Options,
+		protected readonly strictOptions: { admin_strict: boolean; strict: boolean }
 	) {
 		super({
 			domain: strategyOptions.auth0Domain,
@@ -47,6 +48,7 @@ export class Auth0AdminStrategy extends PassportStrategy(Auth0Strategy, AUTH0_AD
 		const validateRes = await validateAdminCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'auth0',
+			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
 		});
 		return {
 			...validateRes,

--- a/packages/medusa-plugin-auth/src/auth-strategies/auth0/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/auth0/index.ts
@@ -11,11 +11,17 @@ export * from './types';
 export default {
 	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
 		if (options.auth0?.admin) {
-			new Auth0AdminStrategy(container, configModule, options.auth0);
+			new Auth0AdminStrategy(container, configModule, options.auth0, {
+				admin_strict: options.admin_strict,
+				strict: options.strict,
+			});
 		}
 
 		if (options.auth0?.store) {
-			new Auth0StoreStrategy(container, configModule, options.auth0);
+			new Auth0StoreStrategy(container, configModule, options.auth0, {
+				store_strict: options.store_strict,
+				strict: options.strict,
+			});
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/auth0/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/auth0/index.ts
@@ -11,17 +11,11 @@ export * from './types';
 export default {
 	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
 		if (options.auth0?.admin) {
-			new Auth0AdminStrategy(container, configModule, options.auth0, {
-				admin_strict: options.admin_strict,
-				strict: options.strict,
-			});
+			new Auth0AdminStrategy(container, configModule, options.auth0, options.strict);
 		}
 
 		if (options.auth0?.store) {
-			new Auth0StoreStrategy(container, configModule, options.auth0, {
-				store_strict: options.store_strict,
-				strict: options.strict,
-			});
+			new Auth0StoreStrategy(container, configModule, options.auth0, options.strict);
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/auth0/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/auth0/store.ts
@@ -10,7 +10,8 @@ export class Auth0StoreStrategy extends PassportStrategy(Auth0Strategy, AUTH0_ST
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: Auth0Options
+		protected readonly strategyOptions: Auth0Options,
+		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
 	) {
 		super({
 			domain: strategyOptions.auth0Domain,
@@ -44,9 +45,11 @@ export class Auth0StoreStrategy extends PassportStrategy(Auth0Strategy, AUTH0_ST
 				accessToken,
 			};
 		}
+
 		const validateRes = await validateStoreCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'auth0',
+			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
 		});
 		return {
 			...validateRes,

--- a/packages/medusa-plugin-auth/src/auth-strategies/auth0/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/auth0/store.ts
@@ -11,7 +11,7 @@ export class Auth0StoreStrategy extends PassportStrategy(Auth0Strategy, AUTH0_ST
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: Auth0Options,
-		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			domain: strategyOptions.auth0Domain,

--- a/packages/medusa-plugin-auth/src/auth-strategies/auth0/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/auth0/store.ts
@@ -5,13 +5,14 @@ import { Auth0Options, Profile, ExtraParams, AUTH0_STORE_STRATEGY_NAME } from '.
 import { PassportStrategy } from '../../core/passport/Strategy';
 import { validateStoreCallback } from '../../core/validate-callback';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { AuthOptions } from '../../types';
 
 export class Auth0StoreStrategy extends PassportStrategy(Auth0Strategy, AUTH0_STORE_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: Auth0Options,
-		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			domain: strategyOptions.auth0Domain,
@@ -49,7 +50,7 @@ export class Auth0StoreStrategy extends PassportStrategy(Auth0Strategy, AUTH0_ST
 		const validateRes = await validateStoreCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'auth0',
-			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 		return {
 			...validateRes,

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/__tests__/store/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/__tests__/store/verify-callback.spec.ts
@@ -86,88 +86,191 @@ describe('Google store strategy verify callback', function () {
 				return container_[name];
 			},
 		} as MedusaContainer;
+	});
 
-		azureStoreStrategy = new AzureStoreStrategy(
-			container,
-			{} as ConfigModule,
-			{
-				store: {
-					identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
-					clientID: 'fake',
-					clientSecret: 'fake',
-					successRedirect: '/admin/auth/azure',
-					failureRedirect: 'http://localhost:9000/app/login',
-					callbackUrl: 'http://localhost:9000/admin/auth/azure/cb',
-					allowHttpForRedirectUrl: true,
+	describe('when strict is set to store', function () {
+		beforeEach(() => {
+			azureStoreStrategy = new AzureStoreStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					store: {
+						identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
+						clientID: 'fake',
+						clientSecret: 'fake',
+						successRedirect: '/admin/auth/azure',
+						failureRedirect: 'http://localhost:9000/app/login',
+						callbackUrl: 'http://localhost:9000/admin/auth/azure/cb',
+						allowHttpForRedirectUrl: true,
+					},
+				} as AzureAuthOptions,
+				'store'
+			);
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				upn: existsEmailWithMetaAndProviderKey,
+			};
+
+			const data = await azureStoreStrategy.validate(req, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				})
+			);
+		});
+
+		it('should fail when the customer exists without the metadata', async () => {
+			profile = {
+				upn: existsEmail,
+			};
+
+			const err = await azureStoreStrategy.validate(req, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
+		});
+
+		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
+			profile = {
+				upn: existsEmailWithMeta,
+			};
+
+			const data = await azureStoreStrategy.validate(req, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should fail when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				upn: existsEmailWithMetaButWrongProviderKey,
+			};
+
+			const err = await azureStoreStrategy.validate(req, profile).catch((err) => err);
+			expect(err).toEqual(
+				new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`)
+			);
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				upn: 'fake',
+				name: {
+					givenName: 'test',
+					familyName: 'test',
 				},
-			} as AzureAuthOptions
-		);
+			};
+
+			const data = await azureStoreStrategy.validate(req, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
 	});
 
-	afterEach(() => {
-		jest.clearAllMocks();
-	});
+	describe('when strict is set to admin', function () {
+		beforeEach(() => {
+			azureStoreStrategy = new AzureStoreStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					store: {
+						identityMetadata: 'https://login.microsoftonline.com/common/.well-known/openid-configuration',
+						clientID: 'fake',
+						clientSecret: 'fake',
+						successRedirect: '/admin/auth/azure',
+						failureRedirect: 'http://localhost:9000/app/login',
+						callbackUrl: 'http://localhost:9000/admin/auth/azure/cb',
+						allowHttpForRedirectUrl: true,
+					},
+				} as AzureAuthOptions,
+				'admin'
+			);
+		});
 
-	it('should succeed', async () => {
-		profile = {
-			upn: existsEmailWithMetaAndProviderKey,
-		};
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
 
-		const data = await azureStoreStrategy.validate(req, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test3',
-			})
-		);
-	});
+		it('should succeed', async () => {
+			profile = {
+				upn: existsEmailWithMetaAndProviderKey,
+			};
 
-	it('should fail when the customer exists without the metadata', async () => {
-		profile = {
-			upn: existsEmail,
-		};
+			const data = await azureStoreStrategy.validate(req, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				})
+			);
+		});
 
-		const err = await azureStoreStrategy.validate(req, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
-	});
+		it('should succeed when the customer exists without the metadata', async () => {
+			profile = {
+				upn: existsEmail,
+			};
 
-	it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
-		profile = {
-			upn: existsEmailWithMeta,
-		};
+			const data = await azureStoreStrategy.validate(req, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+		});
 
-		const data = await azureStoreStrategy.validate(req, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test2',
-			})
-		);
-		expect(updateFn).toHaveBeenCalledTimes(1);
-	});
+		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
+			profile = {
+				upn: existsEmailWithMeta,
+			};
 
-	it('should fail when the metadata exists but auth provider key is wrong', async () => {
-		profile = {
-			upn: existsEmailWithMetaButWrongProviderKey,
-		};
+			const data = await azureStoreStrategy.validate(req, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
 
-		const err = await azureStoreStrategy.validate(req, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`));
-	});
+		it('should succeed when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				upn: existsEmailWithMetaButWrongProviderKey,
+			};
 
-	it('should succeed and create a new customer if it has not been found', async () => {
-		profile = {
-			upn: 'fake',
-			name: {
-				givenName: 'test',
-				familyName: 'test',
-			},
-		};
+			const data = await azureStoreStrategy.validate(req, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test4',
+				})
+			);
+		});
 
-		const data = await azureStoreStrategy.validate(req, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test',
-			})
-		);
-		expect(createFn).toHaveBeenCalledTimes(1);
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				upn: 'fake',
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await azureStoreStrategy.validate(req, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/admin.ts
@@ -5,13 +5,14 @@ import { AZURE_ADMIN_STRATEGY_NAME, AzureAuthOptions, Profile, ResponseType, Res
 import { PassportStrategy } from '../../core/passport/Strategy';
 import { validateAdminCallback } from '../../core/validate-callback';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { AuthOptions } from '../../types';
 
 export class AzureAdminStrategy extends PassportStrategy(AzureStrategy, AZURE_ADMIN_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: AzureAuthOptions,
-		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			identityMetadata: strategyOptions.admin.identityMetadata,
@@ -28,7 +29,7 @@ export class AzureAdminStrategy extends PassportStrategy(AzureStrategy, AZURE_AD
 		});
 	}
 
-	async validate(req: Request, profile: any, done?: Function): Promise<null | { id: string }> {
+	async validate(req: Request, profile: any): Promise<null | { id: string }> {
 		if (this.strategyOptions.admin.verifyCallback) {
 			return await this.strategyOptions.admin.verifyCallback(this.container, req, profile);
 		}
@@ -41,7 +42,7 @@ export class AzureAdminStrategy extends PassportStrategy(AzureStrategy, AZURE_AD
 		return await validateAdminCallback(authprofile, {
 			container: this.container,
 			strategyErrorIdentifier: 'azure_oidc',
-			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/admin.ts
@@ -11,7 +11,7 @@ export class AzureAdminStrategy extends PassportStrategy(AzureStrategy, AZURE_AD
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: AzureAuthOptions,
-		protected readonly strictOptions: { admin_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			identityMetadata: strategyOptions.admin.identityMetadata,

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/admin.ts
@@ -10,7 +10,8 @@ export class AzureAdminStrategy extends PassportStrategy(AzureStrategy, AZURE_AD
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: AzureAuthOptions
+		protected readonly strategyOptions: AzureAuthOptions,
+		protected readonly strictOptions: { admin_strict: boolean; strict: boolean }
 	) {
 		super({
 			identityMetadata: strategyOptions.admin.identityMetadata,
@@ -36,9 +37,11 @@ export class AzureAdminStrategy extends PassportStrategy(AzureStrategy, AZURE_AD
 			emails: [{ value: profile?.upn }],
 			name: { givenName: profile?.name?.givenName, familyName: profile?.name?.familyName },
 		};
+
 		return await validateAdminCallback(authprofile, {
 			container: this.container,
 			strategyErrorIdentifier: 'azure_oidc',
+			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/index.ts
@@ -11,11 +11,17 @@ export * from './store';
 export default {
 	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
 		if (options.azure_oidc?.admin) {
-			new AzureAdminStrategy(container, configModule, options.azure_oidc);
+			new AzureAdminStrategy(container, configModule, options.azure_oidc,{
+				admin_strict: options.admin_strict,
+				strict: options.strict,
+			});
 		}
 
 		if (options.azure_oidc?.store) {
-			new AzureStoreStrategy(container, configModule, options.azure_oidc);
+			new AzureStoreStrategy(container, configModule, options.azure_oidc, {
+				store_strict: options.store_strict,
+				strict: options.strict,
+			});
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/index.ts
@@ -11,17 +11,11 @@ export * from './store';
 export default {
 	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
 		if (options.azure_oidc?.admin) {
-			new AzureAdminStrategy(container, configModule, options.azure_oidc,{
-				admin_strict: options.admin_strict,
-				strict: options.strict,
-			});
+			new AzureAdminStrategy(container, configModule, options.azure_oidc, options.strict);
 		}
 
 		if (options.azure_oidc?.store) {
-			new AzureStoreStrategy(container, configModule, options.azure_oidc, {
-				store_strict: options.store_strict,
-				strict: options.strict,
-			});
+			new AzureStoreStrategy(container, configModule, options.azure_oidc, options.strict);
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
@@ -5,13 +5,14 @@ import { PassportStrategy } from '../../core/passport/Strategy';
 import { AZURE_STORE_STRATEGY_NAME, AzureAuthOptions, Profile, ResponseType, ResponseMode } from './types';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
 import { validateStoreCallback } from '../../core/validate-callback';
+import { AuthOptions } from '../../types';
 
 export class AzureStoreStrategy extends PassportStrategy(AzureStrategy, AZURE_STORE_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: AzureAuthOptions,
-		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			identityMetadata: strategyOptions.store.identityMetadata,
@@ -28,7 +29,7 @@ export class AzureStoreStrategy extends PassportStrategy(AzureStrategy, AZURE_ST
 		});
 	}
 
-	async validate(req: Request, profile: any, done?: Function): Promise<null | { id: string }> {
+	async validate(req: Request, profile: any): Promise<null | { id: string }> {
 		if (this.strategyOptions.store.verifyCallback) {
 			return await this.strategyOptions.store.verifyCallback(this.container, req, profile);
 		}
@@ -41,7 +42,7 @@ export class AzureStoreStrategy extends PassportStrategy(AzureStrategy, AZURE_ST
 		return await validateStoreCallback(authprofile, {
 			container: this.container,
 			strategyErrorIdentifier: 'azure_oidc',
-			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
@@ -11,7 +11,7 @@ export class AzureStoreStrategy extends PassportStrategy(AzureStrategy, AZURE_ST
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: AzureAuthOptions,
-		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			identityMetadata: strategyOptions.store.identityMetadata,

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
@@ -10,7 +10,8 @@ export class AzureStoreStrategy extends PassportStrategy(AzureStrategy, AZURE_ST
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: AzureAuthOptions
+		protected readonly strategyOptions: AzureAuthOptions,
+		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
 	) {
 		super({
 			identityMetadata: strategyOptions.store.identityMetadata,
@@ -36,9 +37,11 @@ export class AzureStoreStrategy extends PassportStrategy(AzureStrategy, AZURE_ST
 			emails: [{ value: profile?.upn }],
 			name: { givenName: profile?.name?.givenName, familyName: profile?.name?.familyName },
 		};
+
 		return await validateStoreCallback(authprofile, {
 			container: this.container,
 			strategyErrorIdentifier: 'azure_oidc',
+			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/__tests__/admin/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/__tests__/admin/verify-callback.spec.ts
@@ -57,55 +57,131 @@ describe('Facebook admin strategy verify callback', function () {
 				return container_[name];
 			},
 		} as MedusaContainer;
-
-		facebookAdminStrategy = new FacebookAdminStrategy(
-			container,
-			{} as ConfigModule,
-			{ clientID: 'fake', clientSecret: 'fake', admin: {} } as FacebookAuthOptions
-		);
 	});
 
-	afterEach(() => {
-		jest.clearAllMocks();
+	describe('when strict is set to admin', function () {
+		beforeEach(() => {
+			facebookAdminStrategy = new FacebookAdminStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					clientID: 'fake',
+					clientSecret: 'fake',
+					admin: {}
+				} as FacebookAuthOptions,
+				"admin"
+			);
+		})
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{value: existsEmailWithProviderKey}],
+			};
+
+			const data = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+		});
+
+		it('should fail when a user exists without the auth provider metadata', async () => {
+			profile = {
+				emails: [{value: existsEmail}],
+			};
+
+			const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Admin with email ${existsEmail} already exists`));
+		});
+
+		it('should fail when a user exists with the wrong auth provider key', async () => {
+			profile = {
+				emails: [{value: existsEmailWithWrongProviderKey}],
+			};
+
+			const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Admin with email ${existsEmailWithWrongProviderKey} already exists`));
+		});
+
+		it('should fail when the user does not exist', async () => {
+			profile = {
+				emails: [{value: 'fake'}],
+			};
+
+			const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
+		});
 	});
 
-	it('should succeed', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithProviderKey }],
-		};
+	describe('when strict is set to store', function () {
+		beforeEach(() => {
+			facebookAdminStrategy = new FacebookAdminStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					clientID: 'fake',
+					clientSecret: 'fake',
+					admin: {}
+				} as FacebookAuthOptions,
+				"store"
+			);
+		})
 
-		const data = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test2',
-			})
-		);
-	});
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
 
-	it('should fail when a user exists without the auth provider metadata', async () => {
-		profile = {
-			emails: [{ value: existsEmail }],
-		};
+		it('should succeed', async () => {
+			profile = {
+				emails: [{value: existsEmailWithProviderKey}],
+			};
 
-		const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Admin with email ${existsEmail} already exists`));
-	});
+			const data = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+		});
 
-	it('should fail when a user exists with the wrong auth provider key', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithWrongProviderKey }],
-		};
+		it('should succeed when a user exists without the auth provider metadata', async () => {
+			profile = {
+				emails: [{value: existsEmail}],
+			};
 
-		const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Admin with email ${existsEmailWithWrongProviderKey} already exists`));
-	});
+			const data = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: "test",
+				})
+			);
+		});
 
-	it('should fail when the user does not exist', async () => {
-		profile = {
-			emails: [{ value: 'fake' }],
-		};
+		it('should succeed when a user exists with the wrong auth provider key', async () => {
+			profile = {
+				emails: [{value: existsEmailWithWrongProviderKey}],
+			};
 
-		const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
+			const data = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: "test3",
+				})
+			);
+		});
+
+		it('should fail when the user does not exist', async () => {
+			profile = {
+				emails: [{value: 'fake'}],
+			};
+
+			const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
+		});
 	});
 });

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/__tests__/admin/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/__tests__/admin/verify-callback.spec.ts
@@ -67,11 +67,11 @@ describe('Facebook admin strategy verify callback', function () {
 				{
 					clientID: 'fake',
 					clientSecret: 'fake',
-					admin: {}
+					admin: {},
 				} as FacebookAuthOptions,
-				"admin"
+				'admin'
 			);
-		})
+		});
 
 		afterEach(() => {
 			jest.clearAllMocks();
@@ -79,7 +79,7 @@ describe('Facebook admin strategy verify callback', function () {
 
 		it('should succeed', async () => {
 			profile = {
-				emails: [{value: existsEmailWithProviderKey}],
+				emails: [{ value: existsEmailWithProviderKey }],
 			};
 
 			const data = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile);
@@ -92,28 +92,34 @@ describe('Facebook admin strategy verify callback', function () {
 
 		it('should fail when a user exists without the auth provider metadata', async () => {
 			profile = {
-				emails: [{value: existsEmail}],
+				emails: [{ value: existsEmail }],
 			};
 
-			const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			const err = await facebookAdminStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
 			expect(err).toEqual(new Error(`Admin with email ${existsEmail} already exists`));
 		});
 
 		it('should fail when a user exists with the wrong auth provider key', async () => {
 			profile = {
-				emails: [{value: existsEmailWithWrongProviderKey}],
+				emails: [{ value: existsEmailWithWrongProviderKey }],
 			};
 
-			const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			const err = await facebookAdminStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
 			expect(err).toEqual(new Error(`Admin with email ${existsEmailWithWrongProviderKey} already exists`));
 		});
 
 		it('should fail when the user does not exist', async () => {
 			profile = {
-				emails: [{value: 'fake'}],
+				emails: [{ value: 'fake' }],
 			};
 
-			const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			const err = await facebookAdminStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
 			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
 		});
 	});
@@ -126,11 +132,11 @@ describe('Facebook admin strategy verify callback', function () {
 				{
 					clientID: 'fake',
 					clientSecret: 'fake',
-					admin: {}
+					admin: {},
 				} as FacebookAuthOptions,
-				"store"
+				'store'
 			);
-		})
+		});
 
 		afterEach(() => {
 			jest.clearAllMocks();
@@ -138,7 +144,7 @@ describe('Facebook admin strategy verify callback', function () {
 
 		it('should succeed', async () => {
 			profile = {
-				emails: [{value: existsEmailWithProviderKey}],
+				emails: [{ value: existsEmailWithProviderKey }],
 			};
 
 			const data = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile);
@@ -151,36 +157,38 @@ describe('Facebook admin strategy verify callback', function () {
 
 		it('should succeed when a user exists without the auth provider metadata', async () => {
 			profile = {
-				emails: [{value: existsEmail}],
+				emails: [{ value: existsEmail }],
 			};
 
 			const data = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile);
 			expect(data).toEqual(
 				expect.objectContaining({
-					id: "test",
+					id: 'test',
 				})
 			);
 		});
 
 		it('should succeed when a user exists with the wrong auth provider key', async () => {
 			profile = {
-				emails: [{value: existsEmailWithWrongProviderKey}],
+				emails: [{ value: existsEmailWithWrongProviderKey }],
 			};
 
 			const data = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile);
 			expect(data).toEqual(
 				expect.objectContaining({
-					id: "test3",
+					id: 'test3',
 				})
 			);
 		});
 
 		it('should fail when the user does not exist', async () => {
 			profile = {
-				emails: [{value: 'fake'}],
+				emails: [{ value: 'fake' }],
 			};
 
-			const err = await facebookAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			const err = await facebookAdminStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
 			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
 		});
 	});

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/__tests__/store/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/__tests__/store/verify-callback.spec.ts
@@ -98,11 +98,11 @@ describe('Facebook store strategy verify callback', function () {
 				{
 					clientID: 'fake',
 					clientSecret: 'fake',
-					store: {}
+					store: {},
 				} as FacebookAuthOptions,
-				"store"
+				'store'
 			);
-		})
+		});
 
 		afterEach(() => {
 			jest.clearAllMocks();
@@ -110,7 +110,7 @@ describe('Facebook store strategy verify callback', function () {
 
 		it('should succeed', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMetaAndProviderKey}],
+				emails: [{ value: existsEmailWithMetaAndProviderKey }],
 			};
 
 			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
@@ -123,16 +123,18 @@ describe('Facebook store strategy verify callback', function () {
 
 		it('should fail when the customer exists without the metadata', async () => {
 			profile = {
-				emails: [{value: existsEmail}],
+				emails: [{ value: existsEmail }],
 			};
 
-			const err = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			const err = await facebookStoreStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
 			expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
 		});
 
 		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMeta}],
+				emails: [{ value: existsEmailWithMeta }],
 			};
 
 			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
@@ -146,16 +148,20 @@ describe('Facebook store strategy verify callback', function () {
 
 		it('should fail when the metadata exists but auth provider key is wrong', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMetaButWrongProviderKey}],
+				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
 			};
 
-			const err = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-			expect(err).toEqual(new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`));
+			const err = await facebookStoreStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
+			expect(err).toEqual(
+				new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`)
+			);
 		});
 
 		it('should succeed and create a new customer if it has not been found', async () => {
 			profile = {
-				emails: [{value: 'fake'}],
+				emails: [{ value: 'fake' }],
 				name: {
 					givenName: 'test',
 					familyName: 'test',
@@ -180,11 +186,11 @@ describe('Facebook store strategy verify callback', function () {
 				{
 					clientID: 'fake',
 					clientSecret: 'fake',
-					store: {}
+					store: {},
 				} as FacebookAuthOptions,
-				"admin"
+				'admin'
 			);
-		})
+		});
 
 		afterEach(() => {
 			jest.clearAllMocks();
@@ -192,7 +198,7 @@ describe('Facebook store strategy verify callback', function () {
 
 		it('should succeed', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMetaAndProviderKey}],
+				emails: [{ value: existsEmailWithMetaAndProviderKey }],
 			};
 
 			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
@@ -205,20 +211,20 @@ describe('Facebook store strategy verify callback', function () {
 
 		it('should fail when the customer exists without the metadata', async () => {
 			profile = {
-				emails: [{value: existsEmail}],
+				emails: [{ value: existsEmail }],
 			};
 
 			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
 			expect(data).toEqual(
 				expect.objectContaining({
-					id: "test",
+					id: 'test',
 				})
 			);
 		});
 
 		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMeta}],
+				emails: [{ value: existsEmailWithMeta }],
 			};
 
 			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
@@ -232,20 +238,20 @@ describe('Facebook store strategy verify callback', function () {
 
 		it('should succeed when the metadata exists but auth provider key is wrong', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMetaButWrongProviderKey}],
+				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
 			};
 
 			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
 			expect(data).toEqual(
 				expect.objectContaining({
-					id: "test4",
+					id: 'test4',
 				})
 			);
 		});
 
 		it('should succeed and create a new customer if it has not been found', async () => {
 			profile = {
-				emails: [{value: 'fake'}],
+				emails: [{ value: 'fake' }],
 				name: {
 					givenName: 'test',
 					familyName: 'test',

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/__tests__/store/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/__tests__/store/verify-callback.spec.ts
@@ -88,78 +88,177 @@ describe('Facebook store strategy verify callback', function () {
 				return container_[name];
 			},
 		} as MedusaContainer;
-
-		facebookStoreStrategy = new FacebookStoreStrategy(
-			container,
-			{} as ConfigModule,
-			{ clientID: 'fake', clientSecret: 'fake', store: {} } as FacebookAuthOptions
-		);
 	});
 
-	afterEach(() => {
-		jest.clearAllMocks();
+	describe('when strict is set to store', function () {
+		beforeEach(() => {
+			facebookStoreStrategy = new FacebookStoreStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					clientID: 'fake',
+					clientSecret: 'fake',
+					store: {}
+				} as FacebookAuthOptions,
+				"store"
+			);
+		})
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMetaAndProviderKey}],
+			};
+
+			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				})
+			);
+		});
+
+		it('should fail when the customer exists without the metadata', async () => {
+			profile = {
+				emails: [{value: existsEmail}],
+			};
+
+			const err = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
+		});
+
+		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMeta}],
+			};
+
+			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should fail when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMetaButWrongProviderKey}],
+			};
+
+			const err = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`));
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				emails: [{value: 'fake'}],
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
 	});
 
-	it('should succeed', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithMetaAndProviderKey }],
-		};
+	describe('when strict is set to admin', function () {
+		beforeEach(() => {
+			facebookStoreStrategy = new FacebookStoreStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					clientID: 'fake',
+					clientSecret: 'fake',
+					store: {}
+				} as FacebookAuthOptions,
+				"admin"
+			);
+		})
 
-		const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test3',
-			})
-		);
-	});
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
 
-	it('should fail when the customer exists without the metadata', async () => {
-		profile = {
-			emails: [{ value: existsEmail }],
-		};
+		it('should succeed', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMetaAndProviderKey}],
+			};
 
-		const err = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
-	});
+			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				})
+			);
+		});
 
-	it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithMeta }],
-		};
+		it('should fail when the customer exists without the metadata', async () => {
+			profile = {
+				emails: [{value: existsEmail}],
+			};
 
-		const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test2',
-			})
-		);
-		expect(updateFn).toHaveBeenCalledTimes(1);
-	});
+			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: "test",
+				})
+			);
+		});
 
-	it('should fail when the metadata exists but auth provider key is wrong', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
-		};
+		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMeta}],
+			};
 
-		const err = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`));
-	});
+			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
 
-	it('should succeed and create a new customer if it has not been found', async () => {
-		profile = {
-			emails: [{ value: 'fake' }],
-			name: {
-				givenName: 'test',
-				familyName: 'test',
-			},
-		};
+		it('should succeed when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMetaButWrongProviderKey}],
+			};
 
-		const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test',
-			})
-		);
-		expect(createFn).toHaveBeenCalledTimes(1);
+			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: "test4",
+				})
+			);
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				emails: [{value: 'fake'}],
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await facebookStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/admin.ts
@@ -11,7 +11,7 @@ export class FacebookAdminStrategy extends PassportStrategy(FacebookStrategy, FA
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: FacebookAuthOptions,
-		protected readonly strictOptions: { admin_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/admin.ts
@@ -5,13 +5,14 @@ import { FACEBOOK_ADMIN_STRATEGY_NAME, FacebookAuthOptions, Profile } from './ty
 import { PassportStrategy } from '../../core/passport/Strategy';
 import { validateAdminCallback } from '../../core/validate-callback';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { AuthOptions } from '../../types';
 
 export class FacebookAdminStrategy extends PassportStrategy(FacebookStrategy, FACEBOOK_ADMIN_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: FacebookAuthOptions,
-		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -41,7 +42,7 @@ export class FacebookAdminStrategy extends PassportStrategy(FacebookStrategy, FA
 		return await validateAdminCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'facebook',
-			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/admin.ts
@@ -10,7 +10,8 @@ export class FacebookAdminStrategy extends PassportStrategy(FacebookStrategy, FA
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: FacebookAuthOptions
+		protected readonly strategyOptions: FacebookAuthOptions,
+		protected readonly strictOptions: { admin_strict: boolean; strict: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -36,7 +37,12 @@ export class FacebookAdminStrategy extends PassportStrategy(FacebookStrategy, FA
 				profile
 			);
 		}
-		return await validateAdminCallback(profile, { container: this.container, strategyErrorIdentifier: 'facebook' });
+
+		return await validateAdminCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: 'facebook',
+			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
+		});
 	}
 }
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/index.ts
@@ -11,11 +11,17 @@ export * from './types';
 export default {
 	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
 		if (options.facebook?.admin) {
-			new FacebookAdminStrategy(container, configModule, options.facebook);
+			new FacebookAdminStrategy(container, configModule, options.facebook, {
+				admin_strict: options.admin_strict,
+				strict: options.strict,
+			});
 		}
 
 		if (options.facebook?.store) {
-			new FacebookStoreStrategy(container, configModule, options.facebook);
+			new FacebookStoreStrategy(container, configModule, options.facebook, {
+				store_strict: options.store_strict,
+				strict: options.strict,
+			});
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/index.ts
@@ -11,17 +11,11 @@ export * from './types';
 export default {
 	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
 		if (options.facebook?.admin) {
-			new FacebookAdminStrategy(container, configModule, options.facebook, {
-				admin_strict: options.admin_strict,
-				strict: options.strict,
-			});
+			new FacebookAdminStrategy(container, configModule, options.facebook, options.strict);
 		}
 
 		if (options.facebook?.store) {
-			new FacebookStoreStrategy(container, configModule, options.facebook, {
-				store_strict: options.store_strict,
-				strict: options.strict,
-			});
+			new FacebookStoreStrategy(container, configModule, options.facebook, options.strict);
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/store.ts
@@ -11,7 +11,7 @@ export class FacebookStoreStrategy extends PassportStrategy(FacebookStrategy, FA
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: FacebookAuthOptions,
-		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/store.ts
@@ -5,13 +5,14 @@ import { FACEBOOK_STORE_STRATEGY_NAME, FacebookAuthOptions, Profile } from './ty
 import { PassportStrategy } from '../../core/passport/Strategy';
 import { validateStoreCallback } from '../../core/validate-callback';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { AuthOptions } from '../../types';
 
 export class FacebookStoreStrategy extends PassportStrategy(FacebookStrategy, FACEBOOK_STORE_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: FacebookAuthOptions,
-		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -41,7 +42,7 @@ export class FacebookStoreStrategy extends PassportStrategy(FacebookStrategy, FA
 		return await validateStoreCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'facebook',
-			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/facebook/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/facebook/store.ts
@@ -10,7 +10,8 @@ export class FacebookStoreStrategy extends PassportStrategy(FacebookStrategy, FA
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: FacebookAuthOptions
+		protected readonly strategyOptions: FacebookAuthOptions,
+		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -36,7 +37,12 @@ export class FacebookStoreStrategy extends PassportStrategy(FacebookStrategy, FA
 				profile
 			);
 		}
-		return await validateStoreCallback(profile, { container: this.container, strategyErrorIdentifier: 'facebook' });
+
+		return await validateStoreCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: 'facebook',
+			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
+		});
 	}
 }
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/firebase/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/firebase/admin.ts
@@ -11,7 +11,8 @@ export class FirebaseAdminStrategy extends PassportStrategy(FirebaseStrategy, FI
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: FirebaseAuthOptions
+		protected readonly strategyOptions: FirebaseAuthOptions,
+		protected readonly strictOptions: { admin_strict: boolean; strict: boolean }
 	) {
 		super({
 			jwtFromRequest: strategyOptions.store.jwtFromRequest ?? ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -26,7 +27,11 @@ export class FirebaseAdminStrategy extends PassportStrategy(FirebaseStrategy, FI
 		}
 
 		const profile: Profile = { emails: [{ value: decodedToken.email }] };
-		return await validateAdminCallback(profile, { container: this.container, strategyErrorIdentifier: 'firebase' });
+		return await validateAdminCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: 'firebase',
+			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
+		});
 	}
 }
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/firebase/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/firebase/admin.ts
@@ -12,7 +12,7 @@ export class FirebaseAdminStrategy extends PassportStrategy(FirebaseStrategy, FI
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: FirebaseAuthOptions,
-		protected readonly strictOptions: { admin_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			jwtFromRequest: strategyOptions.store.jwtFromRequest ?? ExtractJwt.fromAuthHeaderAsBearerToken(),

--- a/packages/medusa-plugin-auth/src/auth-strategies/firebase/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/firebase/admin.ts
@@ -6,13 +6,14 @@ import { PassportStrategy } from '../../core/passport/Strategy';
 import { validateAdminCallback } from '../../core/validate-callback';
 import { firebaseAuthRoutesBuilder } from './utils';
 import { auth } from 'firebase-admin';
+import { AuthOptions } from '../../types';
 
 export class FirebaseAdminStrategy extends PassportStrategy(FirebaseStrategy, FIREBASE_ADMIN_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: FirebaseAuthOptions,
-		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			jwtFromRequest: strategyOptions.store.jwtFromRequest ?? ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -30,7 +31,7 @@ export class FirebaseAdminStrategy extends PassportStrategy(FirebaseStrategy, FI
 		return await validateAdminCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'firebase',
-			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/firebase/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/firebase/index.ts
@@ -32,11 +32,17 @@ export default {
 		}
 
 		if (options.firebase?.admin) {
-			new FirebaseAdminStrategy(container, configModule, options.firebase);
+			new FirebaseAdminStrategy(container, configModule, options.firebase, {
+				admin_strict: options.admin_strict,
+				strict: options.strict,
+			});
 		}
 
 		if (options.firebase?.store) {
-			new FirebaseStoreStrategy(container, configModule, options.firebase);
+			new FirebaseStoreStrategy(container, configModule, options.firebase, {
+				store_strict: options.store_strict,
+				strict: options.strict,
+			});
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/firebase/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/firebase/index.ts
@@ -32,17 +32,11 @@ export default {
 		}
 
 		if (options.firebase?.admin) {
-			new FirebaseAdminStrategy(container, configModule, options.firebase, {
-				admin_strict: options.admin_strict,
-				strict: options.strict,
-			});
+			new FirebaseAdminStrategy(container, configModule, options.firebase, options.strict);
 		}
 
 		if (options.firebase?.store) {
-			new FirebaseStoreStrategy(container, configModule, options.firebase, {
-				store_strict: options.store_strict,
-				strict: options.strict,
-			});
+			new FirebaseStoreStrategy(container, configModule, options.firebase, options.strict);
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/firebase/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/firebase/store.ts
@@ -12,7 +12,7 @@ export class FirebaseStoreStrategy extends PassportStrategy(FirebaseStrategy, FI
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: FirebaseAuthOptions,
-		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			jwtFromRequest: strategyOptions.store.jwtFromRequest ?? ExtractJwt.fromAuthHeaderAsBearerToken(),

--- a/packages/medusa-plugin-auth/src/auth-strategies/firebase/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/firebase/store.ts
@@ -6,13 +6,14 @@ import { validateStoreCallback } from '../../core/validate-callback';
 import { FIREBASE_STORE_STRATEGY_NAME, FirebaseAuthOptions, Profile } from './types';
 import { firebaseAuthRoutesBuilder } from './utils';
 import { auth } from 'firebase-admin';
+import { AuthOptions } from '../../types';
 
 export class FirebaseStoreStrategy extends PassportStrategy(FirebaseStrategy, FIREBASE_STORE_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: FirebaseAuthOptions,
-		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			jwtFromRequest: strategyOptions.store.jwtFromRequest ?? ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -30,7 +31,7 @@ export class FirebaseStoreStrategy extends PassportStrategy(FirebaseStrategy, FI
 		return await validateStoreCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'firebase',
-			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/firebase/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/firebase/store.ts
@@ -11,7 +11,8 @@ export class FirebaseStoreStrategy extends PassportStrategy(FirebaseStrategy, FI
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: FirebaseAuthOptions
+		protected readonly strategyOptions: FirebaseAuthOptions,
+		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
 	) {
 		super({
 			jwtFromRequest: strategyOptions.store.jwtFromRequest ?? ExtractJwt.fromAuthHeaderAsBearerToken(),
@@ -26,7 +27,11 @@ export class FirebaseStoreStrategy extends PassportStrategy(FirebaseStrategy, FI
 		}
 
 		const profile: Profile = { emails: [{ value: decodedToken.email }] };
-		return await validateStoreCallback(profile, { container: this.container, strategyErrorIdentifier: 'firebase' });
+		return await validateStoreCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: 'firebase',
+			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
+		});
 	}
 }
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/__tests__/admin/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/__tests__/admin/verify-callback.spec.ts
@@ -59,13 +59,13 @@ describe('Google admin strategy verify callback', function () {
 		} as MedusaContainer;
 	});
 
-	describe('when admin_strict is set to true', function () {
+	describe('when strict is set to admin', function () {
 		beforeEach(() => {
 			googleAdminStrategy = new GoogleAdminStrategy(
 				container,
 				{} as ConfigModule,
 				{ clientID: 'fake', clientSecret: 'fake', admin: {} } as GoogleAuthOptions,
-				{ admin_strict: true }
+				'admin'
 			);
 		});
 
@@ -114,13 +114,13 @@ describe('Google admin strategy verify callback', function () {
 		});
 	});
 
-	describe('when admin_strict is set to false', function () {
+	describe('when strict is set for store only', function () {
 		beforeEach(() => {
 			googleAdminStrategy = new GoogleAdminStrategy(
 				container,
 				{} as ConfigModule,
 				{ clientID: 'fake', clientSecret: 'fake', admin: {} } as GoogleAuthOptions,
-				{ admin_strict: false }
+				'store'
 			);
 		});
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/__tests__/store/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/__tests__/store/verify-callback.spec.ts
@@ -229,10 +229,12 @@ describe('Google store strategy verify callback', function () {
 				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
 			};
 
-			const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile)
-			expect(data).toEqual(expect.objectContaining({
-				id: 'test4',
-			}));
+			const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test4',
+				})
+			);
 		});
 
 		it('should succeed and create a new customer if it has not been found', async () => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/__tests__/store/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/__tests__/store/verify-callback.spec.ts
@@ -88,78 +88,169 @@ describe('Google store strategy verify callback', function () {
 				return container_[name];
 			},
 		} as MedusaContainer;
-
-		googleStoreStrategy = new GoogleStoreStrategy(
-			container,
-			{} as ConfigModule,
-			{ clientID: 'fake', clientSecret: 'fake', store: {} } as GoogleAuthOptions
-		);
 	});
 
-	afterEach(() => {
-		jest.clearAllMocks();
+	describe('when strict is set to store', function () {
+		beforeEach(() => {
+			googleStoreStrategy = new GoogleStoreStrategy(
+				container,
+				{} as ConfigModule,
+				{ clientID: 'fake', clientSecret: 'fake', store: {} } as GoogleAuthOptions,
+				'store'
+			);
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaAndProviderKey }],
+			};
+
+			const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				})
+			);
+		});
+
+		it('should fail when the customer exists without the metadata', async () => {
+			profile = {
+				emails: [{ value: existsEmail }],
+			};
+
+			const err = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
+		});
+
+		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMeta }],
+			};
+
+			const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should fail when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
+			};
+
+			const err = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(
+				new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`)
+			);
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				emails: [{ value: 'fake' }],
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
 	});
 
-	it('should succeed', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithMetaAndProviderKey }],
-		};
+	describe('when strict is set to admin only', function () {
+		beforeEach(() => {
+			googleStoreStrategy = new GoogleStoreStrategy(
+				container,
+				{} as ConfigModule,
+				{ clientID: 'fake', clientSecret: 'fake', store: {} } as GoogleAuthOptions,
+				'admin'
+			);
+		});
 
-		const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test3',
-			})
-		);
-	});
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
 
-	it('should fail when the customer exists without the metadata', async () => {
-		profile = {
-			emails: [{ value: existsEmail }],
-		};
+		it('should succeed', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaAndProviderKey }],
+			};
 
-		const err = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
-	});
+			const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				})
+			);
+		});
 
-	it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithMeta }],
-		};
+		it('should succeed when the customer exists without the metadata', async () => {
+			profile = {
+				emails: [{ value: existsEmail }],
+			};
 
-		const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test2',
-			})
-		);
-		expect(updateFn).toHaveBeenCalledTimes(1);
-	});
+			const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+		});
 
-	it('should fail when the metadata exists but auth provider key is wrong', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
-		};
+		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMeta }],
+			};
 
-		const err = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`));
-	});
+			const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
 
-	it('should succeed and create a new customer if it has not been found', async () => {
-		profile = {
-			emails: [{ value: 'fake' }],
-			name: {
-				givenName: 'test',
-				familyName: 'test',
-			},
-		};
+		it('should succeed when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
+			};
 
-		const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test',
-			})
-		);
-		expect(createFn).toHaveBeenCalledTimes(1);
+			const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile)
+			expect(data).toEqual(expect.objectContaining({
+				id: 'test4',
+			}));
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				emails: [{ value: 'fake' }],
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await googleStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/admin.ts
@@ -10,7 +10,8 @@ export class GoogleAdminStrategy extends PassportStrategy(GoogleStrategy, GOOGLE
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: GoogleAuthOptions
+		protected readonly strategyOptions: GoogleAuthOptions,
+		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -36,7 +37,11 @@ export class GoogleAdminStrategy extends PassportStrategy(GoogleStrategy, GOOGLE
 			);
 		}
 
-		return await validateAdminCallback(profile, { container: this.container, strategyErrorIdentifier: 'google' });
+		return await validateAdminCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: 'google',
+			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
+		});
 	}
 }
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/admin.ts
@@ -5,13 +5,14 @@ import { GOOGLE_ADMIN_STRATEGY_NAME, GoogleAuthOptions, Profile } from './types'
 import { PassportStrategy } from '../../core/passport/Strategy';
 import { validateAdminCallback } from '../../core/validate-callback';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { AuthOptions } from '../../types';
 
 export class GoogleAdminStrategy extends PassportStrategy(GoogleStrategy, GOOGLE_ADMIN_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: GoogleAuthOptions,
-		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -40,7 +41,7 @@ export class GoogleAdminStrategy extends PassportStrategy(GoogleStrategy, GOOGLE
 		return await validateAdminCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'google',
-			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/index.ts
@@ -11,17 +11,11 @@ export * from './store';
 export default {
 	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
 		if (options.google?.admin) {
-			new GoogleAdminStrategy(container, configModule, options.google, {
-				admin_strict: options.admin_strict,
-				strict: options.strict,
-			});
+			new GoogleAdminStrategy(container, configModule, options.google, options.strict);
 		}
 
 		if (options.google?.store) {
-			new GoogleStoreStrategy(container, configModule, options.google, {
-				store_strict: options.store_strict,
-				strict: options.strict,
-			});
+			new GoogleStoreStrategy(container, configModule, options.google, options.strict);
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/index.ts
@@ -11,11 +11,17 @@ export * from './store';
 export default {
 	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
 		if (options.google?.admin) {
-			new GoogleAdminStrategy(container, configModule, options.google);
+			new GoogleAdminStrategy(container, configModule, options.google, {
+				admin_strict: options.admin_strict,
+				strict: options.strict,
+			});
 		}
 
 		if (options.google?.store) {
-			new GoogleStoreStrategy(container, configModule, options.google);
+			new GoogleStoreStrategy(container, configModule, options.google, {
+				store_strict: options.store_strict,
+				strict: options.strict,
+			});
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/store.ts
@@ -10,7 +10,8 @@ export class GoogleStoreStrategy extends PassportStrategy(GoogleStrategy, GOOGLE
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: GoogleAuthOptions
+		protected readonly strategyOptions: GoogleAuthOptions,
+		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -35,7 +36,12 @@ export class GoogleStoreStrategy extends PassportStrategy(GoogleStrategy, GOOGLE
 				profile
 			);
 		}
-		return await validateStoreCallback(profile, { container: this.container, strategyErrorIdentifier: 'google' });
+
+		return await validateStoreCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: 'google',
+			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
+		});
 	}
 }
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/store.ts
@@ -11,7 +11,7 @@ export class GoogleStoreStrategy extends PassportStrategy(GoogleStrategy, GOOGLE
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: GoogleAuthOptions,
-		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,

--- a/packages/medusa-plugin-auth/src/auth-strategies/google/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/google/store.ts
@@ -5,13 +5,14 @@ import { PassportStrategy } from '../../core/passport/Strategy';
 import { GOOGLE_STORE_STRATEGY_NAME, GoogleAuthOptions, Profile } from './types';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
 import { validateStoreCallback } from '../../core/validate-callback';
+import { AuthOptions } from '../../types';
 
 export class GoogleStoreStrategy extends PassportStrategy(GoogleStrategy, GOOGLE_STORE_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: GoogleAuthOptions,
-		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -40,7 +41,7 @@ export class GoogleStoreStrategy extends PassportStrategy(GoogleStrategy, GOOGLE
 		return await validateStoreCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'google',
-			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/__tests__/admin/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/__tests__/admin/verify-callback.spec.ts
@@ -57,55 +57,131 @@ describe('Linkedin admin strategy verify callback', function () {
 				return container_[name];
 			},
 		} as MedusaContainer;
-
-		linkedinAdminStrategy = new LinkedinAdminStrategy(
-			container,
-			{} as ConfigModule,
-			{ clientID: 'fake', clientSecret: 'fake', admin: {} } as LinkedinAuthOptions
-		);
 	});
 
-	afterEach(() => {
-		jest.clearAllMocks();
+	describe('when strict is set to admin', function () {
+		beforeEach(() => {
+			linkedinAdminStrategy = new LinkedinAdminStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					clientID: 'fake',
+					clientSecret: 'fake',
+					admin: {}
+				} as LinkedinAuthOptions,
+				"admin"
+			);
+		})
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{value: existsEmailWithProviderKey}],
+			};
+
+			const data = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+		});
+
+		it('should fail when a user exists without the auth provider metadata', async () => {
+			profile = {
+				emails: [{value: existsEmail}],
+			};
+
+			const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Admin with email ${existsEmail} already exists`));
+		});
+
+		it('should fail when a user exists with the wrong auth provider key', async () => {
+			profile = {
+				emails: [{value: existsEmailWithWrongProviderKey}],
+			};
+
+			const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Admin with email ${existsEmailWithWrongProviderKey} already exists`));
+		});
+
+		it('should fail when the user does not exist', async () => {
+			profile = {
+				emails: [{value: 'fake'}],
+			};
+
+			const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
+		});
 	});
 
-	it('should succeed', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithProviderKey }],
-		};
+	describe('when strict is set to store', function () {
+		beforeEach(() => {
+			linkedinAdminStrategy = new LinkedinAdminStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					clientID: 'fake',
+					clientSecret: 'fake',
+					admin: {}
+				} as LinkedinAuthOptions,
+				"store"
+			);
+		})
 
-		const data = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test2',
-			})
-		);
-	});
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
 
-	it('should fail when a user exists without the auth provider metadata', async () => {
-		profile = {
-			emails: [{ value: existsEmail }],
-		};
+		it('should succeed', async () => {
+			profile = {
+				emails: [{value: existsEmailWithProviderKey}],
+			};
 
-		const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Admin with email ${existsEmail} already exists`));
-	});
+			const data = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+		});
 
-	it('should fail when a user exists with the wrong auth provider key', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithWrongProviderKey }],
-		};
+		it('should succeed when a user exists without the auth provider metadata', async () => {
+			profile = {
+				emails: [{value: existsEmail}],
+			};
 
-		const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Admin with email ${existsEmailWithWrongProviderKey} already exists`));
-	});
+			const data = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: "test",
+				})
+			);
+		});
 
-	it('should fail when the user does not exist', async () => {
-		profile = {
-			emails: [{ value: 'fake' }],
-		};
+		it('should succeed when a user exists with the wrong auth provider key', async () => {
+			profile = {
+				emails: [{value: existsEmailWithWrongProviderKey}],
+			};
 
-		const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
+			const data = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: "test3",
+				})
+			);
+		});
+
+		it('should fail when the user does not exist', async () => {
+			profile = {
+				emails: [{value: 'fake'}],
+			};
+
+			const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
+		});
 	});
 });

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/__tests__/admin/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/__tests__/admin/verify-callback.spec.ts
@@ -67,11 +67,11 @@ describe('Linkedin admin strategy verify callback', function () {
 				{
 					clientID: 'fake',
 					clientSecret: 'fake',
-					admin: {}
+					admin: {},
 				} as LinkedinAuthOptions,
-				"admin"
+				'admin'
 			);
-		})
+		});
 
 		afterEach(() => {
 			jest.clearAllMocks();
@@ -79,7 +79,7 @@ describe('Linkedin admin strategy verify callback', function () {
 
 		it('should succeed', async () => {
 			profile = {
-				emails: [{value: existsEmailWithProviderKey}],
+				emails: [{ value: existsEmailWithProviderKey }],
 			};
 
 			const data = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile);
@@ -92,28 +92,34 @@ describe('Linkedin admin strategy verify callback', function () {
 
 		it('should fail when a user exists without the auth provider metadata', async () => {
 			profile = {
-				emails: [{value: existsEmail}],
+				emails: [{ value: existsEmail }],
 			};
 
-			const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			const err = await linkedinAdminStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
 			expect(err).toEqual(new Error(`Admin with email ${existsEmail} already exists`));
 		});
 
 		it('should fail when a user exists with the wrong auth provider key', async () => {
 			profile = {
-				emails: [{value: existsEmailWithWrongProviderKey}],
+				emails: [{ value: existsEmailWithWrongProviderKey }],
 			};
 
-			const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			const err = await linkedinAdminStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
 			expect(err).toEqual(new Error(`Admin with email ${existsEmailWithWrongProviderKey} already exists`));
 		});
 
 		it('should fail when the user does not exist', async () => {
 			profile = {
-				emails: [{value: 'fake'}],
+				emails: [{ value: 'fake' }],
 			};
 
-			const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			const err = await linkedinAdminStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
 			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
 		});
 	});
@@ -126,11 +132,11 @@ describe('Linkedin admin strategy verify callback', function () {
 				{
 					clientID: 'fake',
 					clientSecret: 'fake',
-					admin: {}
+					admin: {},
 				} as LinkedinAuthOptions,
-				"store"
+				'store'
 			);
-		})
+		});
 
 		afterEach(() => {
 			jest.clearAllMocks();
@@ -138,7 +144,7 @@ describe('Linkedin admin strategy verify callback', function () {
 
 		it('should succeed', async () => {
 			profile = {
-				emails: [{value: existsEmailWithProviderKey}],
+				emails: [{ value: existsEmailWithProviderKey }],
 			};
 
 			const data = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile);
@@ -151,36 +157,38 @@ describe('Linkedin admin strategy verify callback', function () {
 
 		it('should succeed when a user exists without the auth provider metadata', async () => {
 			profile = {
-				emails: [{value: existsEmail}],
+				emails: [{ value: existsEmail }],
 			};
 
 			const data = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile);
 			expect(data).toEqual(
 				expect.objectContaining({
-					id: "test",
+					id: 'test',
 				})
 			);
 		});
 
 		it('should succeed when a user exists with the wrong auth provider key', async () => {
 			profile = {
-				emails: [{value: existsEmailWithWrongProviderKey}],
+				emails: [{ value: existsEmailWithWrongProviderKey }],
 			};
 
 			const data = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile);
 			expect(data).toEqual(
 				expect.objectContaining({
-					id: "test3",
+					id: 'test3',
 				})
 			);
 		});
 
 		it('should fail when the user does not exist', async () => {
 			profile = {
-				emails: [{value: 'fake'}],
+				emails: [{ value: 'fake' }],
 			};
 
-			const err = await linkedinAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			const err = await linkedinAdminStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
 			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
 		});
 	});

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/__tests__/store/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/__tests__/store/verify-callback.spec.ts
@@ -88,78 +88,177 @@ describe('Linkedin store strategy verify callback', function () {
 				return container_[name];
 			},
 		} as MedusaContainer;
-
-		linkedinStoreStrategy = new LinkedinStoreStrategy(
-			container,
-			{} as ConfigModule,
-			{ clientID: 'fake', clientSecret: 'fake', store: {} } as LinkedinAuthOptions
-		);
 	});
 
-	afterEach(() => {
-		jest.clearAllMocks();
+	describe('when strict is set to store', function () {
+		beforeEach(() => {
+			linkedinStoreStrategy = new LinkedinStoreStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					clientID: 'fake',
+					clientSecret: 'fake',
+					store: {}
+				} as LinkedinAuthOptions,
+				"store"
+			);
+		})
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMetaAndProviderKey}],
+			};
+
+			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				})
+			);
+		});
+
+		it('should fail when the customer exists without the metadata', async () => {
+			profile = {
+				emails: [{value: existsEmail}],
+			};
+
+			const err = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
+		});
+
+		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMeta}],
+			};
+
+			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should fail when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMetaButWrongProviderKey}],
+			};
+
+			const err = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`));
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				emails: [{value: 'fake'}],
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
 	});
 
-	it('should succeed', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithMetaAndProviderKey }],
-		};
+	describe('when strict is set to admn', function () {
+		beforeEach(() => {
+			linkedinStoreStrategy = new LinkedinStoreStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					clientID: 'fake',
+					clientSecret: 'fake',
+					store: {}
+				} as LinkedinAuthOptions,
+				"admin"
+			);
+		})
 
-		const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test3',
-			})
-		);
-	});
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
 
-	it('should fail when the customer exists without the metadata', async () => {
-		profile = {
-			emails: [{ value: existsEmail }],
-		};
+		it('should succeed', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMetaAndProviderKey}],
+			};
 
-		const err = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
-	});
+			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				})
+			);
+		});
 
-	it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithMeta }],
-		};
+		it('should succeed when the customer exists without the metadata', async () => {
+			profile = {
+				emails: [{value: existsEmail}],
+			};
 
-		const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test2',
-			})
-		);
-		expect(updateFn).toHaveBeenCalledTimes(1);
-	});
+			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: "test",
+				})
+			);
+		});
 
-	it('should fail when the metadata exists but auth provider key is wrong', async () => {
-		profile = {
-			emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
-		};
+		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMeta}],
+			};
 
-		const err = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-		expect(err).toEqual(new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`));
-	});
+			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
 
-	it('should succeed and create a new customer if it has not been found', async () => {
-		profile = {
-			emails: [{ value: 'fake' }],
-			name: {
-				givenName: 'test',
-				familyName: 'test',
-			},
-		};
+		it('should succeed when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				emails: [{value: existsEmailWithMetaButWrongProviderKey}],
+			};
 
-		const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
-		expect(data).toEqual(
-			expect.objectContaining({
-				id: 'test',
-			})
-		);
-		expect(createFn).toHaveBeenCalledTimes(1);
+			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: "test4",
+				})
+			);
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				emails: [{value: 'fake'}],
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
 	});
 });

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/__tests__/store/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/__tests__/store/verify-callback.spec.ts
@@ -98,11 +98,11 @@ describe('Linkedin store strategy verify callback', function () {
 				{
 					clientID: 'fake',
 					clientSecret: 'fake',
-					store: {}
+					store: {},
 				} as LinkedinAuthOptions,
-				"store"
+				'store'
 			);
-		})
+		});
 
 		afterEach(() => {
 			jest.clearAllMocks();
@@ -110,7 +110,7 @@ describe('Linkedin store strategy verify callback', function () {
 
 		it('should succeed', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMetaAndProviderKey}],
+				emails: [{ value: existsEmailWithMetaAndProviderKey }],
 			};
 
 			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
@@ -123,16 +123,18 @@ describe('Linkedin store strategy verify callback', function () {
 
 		it('should fail when the customer exists without the metadata', async () => {
 			profile = {
-				emails: [{value: existsEmail}],
+				emails: [{ value: existsEmail }],
 			};
 
-			const err = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			const err = await linkedinStoreStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
 			expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
 		});
 
 		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMeta}],
+				emails: [{ value: existsEmailWithMeta }],
 			};
 
 			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
@@ -146,16 +148,20 @@ describe('Linkedin store strategy verify callback', function () {
 
 		it('should fail when the metadata exists but auth provider key is wrong', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMetaButWrongProviderKey}],
+				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
 			};
 
-			const err = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
-			expect(err).toEqual(new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`));
+			const err = await linkedinStoreStrategy
+				.validate(req, accessToken, refreshToken, profile)
+				.catch((err) => err);
+			expect(err).toEqual(
+				new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`)
+			);
 		});
 
 		it('should succeed and create a new customer if it has not been found', async () => {
 			profile = {
-				emails: [{value: 'fake'}],
+				emails: [{ value: 'fake' }],
 				name: {
 					givenName: 'test',
 					familyName: 'test',
@@ -180,11 +186,11 @@ describe('Linkedin store strategy verify callback', function () {
 				{
 					clientID: 'fake',
 					clientSecret: 'fake',
-					store: {}
+					store: {},
 				} as LinkedinAuthOptions,
-				"admin"
+				'admin'
 			);
-		})
+		});
 
 		afterEach(() => {
 			jest.clearAllMocks();
@@ -192,7 +198,7 @@ describe('Linkedin store strategy verify callback', function () {
 
 		it('should succeed', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMetaAndProviderKey}],
+				emails: [{ value: existsEmailWithMetaAndProviderKey }],
 			};
 
 			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
@@ -205,20 +211,20 @@ describe('Linkedin store strategy verify callback', function () {
 
 		it('should succeed when the customer exists without the metadata', async () => {
 			profile = {
-				emails: [{value: existsEmail}],
+				emails: [{ value: existsEmail }],
 			};
 
 			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
 			expect(data).toEqual(
 				expect.objectContaining({
-					id: "test",
+					id: 'test',
 				})
 			);
 		});
 
 		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMeta}],
+				emails: [{ value: existsEmailWithMeta }],
 			};
 
 			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
@@ -232,20 +238,20 @@ describe('Linkedin store strategy verify callback', function () {
 
 		it('should succeed when the metadata exists but auth provider key is wrong', async () => {
 			profile = {
-				emails: [{value: existsEmailWithMetaButWrongProviderKey}],
+				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
 			};
 
 			const data = await linkedinStoreStrategy.validate(req, accessToken, refreshToken, profile);
 			expect(data).toEqual(
 				expect.objectContaining({
-					id: "test4",
+					id: 'test4',
 				})
 			);
 		});
 
 		it('should succeed and create a new customer if it has not been found', async () => {
 			profile = {
-				emails: [{value: 'fake'}],
+				emails: [{ value: 'fake' }],
 				name: {
 					givenName: 'test',
 					familyName: 'test',

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/admin.ts
@@ -5,13 +5,14 @@ import { LINKEDIN_ADMIN_STRATEGY_NAME, LinkedinAuthOptions, Profile } from './ty
 import { PassportStrategy } from '../../core/passport/Strategy';
 import { validateAdminCallback } from '../../core/validate-callback';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { AuthOptions } from '../../types';
 
 export class LinkedinAdminStrategy extends PassportStrategy(LinkedinStrategy, LINKEDIN_ADMIN_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: LinkedinAuthOptions,
-		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -42,7 +43,7 @@ export class LinkedinAdminStrategy extends PassportStrategy(LinkedinStrategy, LI
 		return await validateAdminCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'linkedin',
-			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/admin.ts
@@ -11,7 +11,7 @@ export class LinkedinAdminStrategy extends PassportStrategy(LinkedinStrategy, LI
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: LinkedinAuthOptions,
-		protected readonly strictOptions: { admin_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { admin_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/admin.ts
@@ -10,7 +10,8 @@ export class LinkedinAdminStrategy extends PassportStrategy(LinkedinStrategy, LI
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: LinkedinAuthOptions
+		protected readonly strategyOptions: LinkedinAuthOptions,
+		protected readonly strictOptions: { admin_strict: boolean; strict: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -38,7 +39,11 @@ export class LinkedinAdminStrategy extends PassportStrategy(LinkedinStrategy, LI
 			);
 		}
 
-		return await validateAdminCallback(profile, { container: this.container, strategyErrorIdentifier: 'linkedin' });
+		return await validateAdminCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: 'linkedin',
+			strict: this.strictOptions.admin_strict ?? this.strictOptions.strict,
+		});
 	}
 }
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/index.ts
@@ -15,11 +15,17 @@ export * from './store';
 export default {
 	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
 		if (options.linkedin?.admin) {
-			new LinkedinAdminStrategy(container, configModule, options.linkedin);
+			new LinkedinAdminStrategy(container, configModule, options.linkedin, {
+				admin_strict: options.admin_strict,
+				strict: options.strict,
+			});
 		}
 
 		if (options.linkedin?.store) {
-			new LinkedinStoreStrategy(container, configModule, options.linkedin);
+			new LinkedinStoreStrategy(container, configModule, options.linkedin, {
+				store_strict: options.store_strict,
+				strict: options.strict,
+			});
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/index.ts
@@ -15,17 +15,11 @@ export * from './store';
 export default {
 	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
 		if (options.linkedin?.admin) {
-			new LinkedinAdminStrategy(container, configModule, options.linkedin, {
-				admin_strict: options.admin_strict,
-				strict: options.strict,
-			});
+			new LinkedinAdminStrategy(container, configModule, options.linkedin, options.strict);
 		}
 
 		if (options.linkedin?.store) {
-			new LinkedinStoreStrategy(container, configModule, options.linkedin, {
-				store_strict: options.store_strict,
-				strict: options.strict,
-			});
+			new LinkedinStoreStrategy(container, configModule, options.linkedin, options.strict);
 		}
 	},
 	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/store.ts
@@ -11,7 +11,7 @@ export class LinkedinStoreStrategy extends PassportStrategy(LinkedinStrategy, LI
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: LinkedinAuthOptions,
-		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
+		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/store.ts
@@ -10,7 +10,8 @@ export class LinkedinStoreStrategy extends PassportStrategy(LinkedinStrategy, LI
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
-		protected readonly strategyOptions: LinkedinAuthOptions
+		protected readonly strategyOptions: LinkedinAuthOptions,
+		protected readonly strictOptions: { store_strict: boolean; strict: boolean }
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -37,7 +38,12 @@ export class LinkedinStoreStrategy extends PassportStrategy(LinkedinStrategy, LI
 				profile
 			);
 		}
-		return await validateStoreCallback(profile, { container: this.container, strategyErrorIdentifier: 'linkedin' });
+
+		return await validateStoreCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: 'linkedin',
+			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
+		});
 	}
 }
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/linkedin/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/linkedin/store.ts
@@ -5,13 +5,14 @@ import { PassportStrategy } from '../../core/passport/Strategy';
 import { LINKEDIN_STORE_STRATEGY_NAME, LinkedinAuthOptions, Profile } from './types';
 import { validateStoreCallback } from '../../core/validate-callback';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { AuthOptions } from '../../types';
 
 export class LinkedinStoreStrategy extends PassportStrategy(LinkedinStrategy, LINKEDIN_STORE_STRATEGY_NAME) {
 	constructor(
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: LinkedinAuthOptions,
-		protected readonly strictOptions?: { store_strict?: boolean; strict?: boolean }
+		protected readonly strict?: AuthOptions['strict']
 	) {
 		super({
 			clientID: strategyOptions.clientID,
@@ -42,7 +43,7 @@ export class LinkedinStoreStrategy extends PassportStrategy(LinkedinStrategy, LI
 		return await validateStoreCallback(profile, {
 			container: this.container,
 			strategyErrorIdentifier: 'linkedin',
-			strict: this.strictOptions.store_strict ?? this.strictOptions.strict,
+			strict: this.strict,
 		});
 	}
 }

--- a/packages/medusa-plugin-auth/src/core/validate-callback.ts
+++ b/packages/medusa-plugin-auth/src/core/validate-callback.ts
@@ -13,6 +13,10 @@ import {
 /**
  * Default validate callback used by an admin passport strategy
  *
+ * @param profile
+ * @param container
+ * @param strategyErrorIdentifier
+ * @param strict
  */
 export async function validateAdminCallback<
 	T extends { emails?: { value: string }[] } = {
@@ -23,7 +27,8 @@ export async function validateAdminCallback<
 	{
 		container,
 		strategyErrorIdentifier,
-	}: { container: MedusaContainer; strategyErrorIdentifier: StrategyErrorIdentifierType }
+		strict,
+	}: { container: MedusaContainer; strategyErrorIdentifier: StrategyErrorIdentifierType; strict?: boolean }
 ): Promise<{ id: string } | never> {
 	const userService: UserService = container.resolve('userService');
 	const email = profile.emails?.[0]?.value;
@@ -38,7 +43,11 @@ export async function validateAdminCallback<
 	const user = await userService.retrieveByEmail(email).catch(() => void 0);
 
 	if (user) {
-		if (!user.metadata || user.metadata[AUTH_PROVIDER_KEY] !== strategyNames[strategyErrorIdentifier].admin) {
+		strict ??= true;
+		if (
+			strict &&
+			(!user.metadata || user.metadata[AUTH_PROVIDER_KEY] !== strategyNames[strategyErrorIdentifier].admin)
+		) {
 			throw new MedusaError(MedusaError.Types.INVALID_DATA, `Admin with email ${email} already exists`);
 		}
 	} else {
@@ -54,6 +63,7 @@ export async function validateAdminCallback<
  * @param profile
  * @param strategyErrorIdentifier It will be used to compose the error message in case of an error (e.g Google, Facebook)
  * @param container
+ * @param strict
  */
 export async function validateStoreCallback<
 	T extends {
@@ -70,7 +80,8 @@ export async function validateStoreCallback<
 	{
 		container,
 		strategyErrorIdentifier,
-	}: { container: MedusaContainer; strategyErrorIdentifier: StrategyErrorIdentifierType }
+		strict,
+	}: { container: MedusaContainer; strategyErrorIdentifier: StrategyErrorIdentifierType; strict?: boolean }
 ): Promise<{ id: string } | never> {
 	const manager: EntityManager = container.resolve('manager');
 	const customerService: CustomerService = container.resolve('customerService');
@@ -116,10 +127,12 @@ export async function validateStoreCallback<
 				});
 			}
 
+			strict ??= true;
 			if (
-				!customer.metadata ||
-				!customer.metadata[CUSTOMER_METADATA_KEY] ||
-				customer.metadata[AUTH_PROVIDER_KEY] !== strategyNames[strategyErrorIdentifier].store
+				strict &&
+				(!customer.metadata ||
+					!customer.metadata[CUSTOMER_METADATA_KEY] ||
+					customer.metadata[AUTH_PROVIDER_KEY] !== strategyNames[strategyErrorIdentifier].store)
 			) {
 				throw new MedusaError(MedusaError.Types.INVALID_DATA, `Customer with email ${email} already exists`);
 			} else {

--- a/packages/medusa-plugin-auth/src/types/index.ts
+++ b/packages/medusa-plugin-auth/src/types/index.ts
@@ -32,10 +32,12 @@ export type StrategyExport = {
 
 export type AuthOptions = ProviderOptions & {
 	/**
-	 * When set, the domain will only allow the user to authenticate using the prodider
-	 * that has been used to create the account
+	 * When set to admin | store | all,  will only allow the user to authenticate using the provider
+	 * that has been used to create the account on the domain that strict is set to.
+	 *
+	 * @default 'all'
 	 */
-	strict?: 'admin' | 'store' | 'all';
+	strict?: 'admin' | 'store' | 'all' | 'none';
 };
 
 export type ProviderOptions = {

--- a/packages/medusa-plugin-auth/src/types/index.ts
+++ b/packages/medusa-plugin-auth/src/types/index.ts
@@ -32,22 +32,10 @@ export type StrategyExport = {
 
 export type AuthOptions = ProviderOptions & {
 	/**
-	 * When no value is provided, the default is true.
-	 * It means that the default behaviour will be that a user can only login with one provider.
-	 * Set it to false if you want to allow a user to login with multiple providers.
+	 * When set, the domain will only allow the user to authenticate using the prodider
+	 * that has been used to create the account
 	 */
-	admin_strict?: boolean;
-	/**
-	 * When no value is provided, the default is true.
-	 * It means that the default behaviour will be that a user can only login with one provider.
-	 * Set it to false if you want to allow a user to login with multiple providers.
-	 */
-	store_strict?: boolean;
-	/**
-	 * It is a shortcut of the `admin_strict` and `store_strict` options. If you set
-	 * this option, both domain will be set to the same value.
-	 */
-	strict?: boolean;
+	strict?: 'admin' | 'store' | 'all';
 };
 
 export type ProviderOptions = {

--- a/packages/medusa-plugin-auth/src/types/index.ts
+++ b/packages/medusa-plugin-auth/src/types/index.ts
@@ -30,7 +30,27 @@ export type StrategyExport = {
 	getRouter?: (configModule: ConfigModule, options: AuthOptions) => Router[];
 };
 
-export type AuthOptions = {
+export type AuthOptions = ProviderOptions & {
+	/**
+	 * When no value is provided, the default is true.
+	 * It means that the default behaviour will be that a user can only login with one provider.
+	 * Set it to false if you want to allow a user to login with multiple providers.
+	 */
+	admin_strict?: boolean;
+	/**
+	 * When no value is provided, the default is true.
+	 * It means that the default behaviour will be that a user can only login with one provider.
+	 * Set it to false if you want to allow a user to login with multiple providers.
+	 */
+	store_strict?: boolean;
+	/**
+	 * It is a shortcut of the `admin_strict` and `store_strict` options. If you set
+	 * this option, both domain will be set to the same value.
+	 */
+	strict?: boolean;
+};
+
+export type ProviderOptions = {
 	google?: GoogleAuthOptions;
 	facebook?: FacebookAuthOptions;
 	linkedin?: LinkedinAuthOptions;
@@ -39,7 +59,7 @@ export type AuthOptions = {
 	azure_oidc?: AzureAuthOptions;
 };
 
-export type StrategyErrorIdentifierType = keyof AuthOptions;
+export type StrategyErrorIdentifierType = keyof ProviderOptions;
 export type StrategyNames = {
 	[key in StrategyErrorIdentifierType]: {
 		admin: string;


### PR DESCRIPTION
**What**

Add support for strict options
- strict

When `strict ` is set to `all`, then both admin and store domains will be strict.
When set to `admin` is enabled, then admin domain will be strict.
When set to`store` is enabled, then store domain will be strict.