### PR TITLE
Draft: initial supabase-auth strategy

### DIFF
--- a/packages/medusa-plugin-auth/package.json
+++ b/packages/medusa-plugin-auth/package.json
@@ -67,6 +67,7 @@
     "express": "^4.18.1",
     "firebase-admin": "^11.4.1",
     "jsonwebtoken": "^8.5.1",
+    "nestjs-supabase-auth": "^1.0.9",
     "passport-auth0": "^1.4.3",
     "passport-azure-ad": "^4.3.5",
     "passport-facebook": "^3.0.0",

--- a/packages/medusa-plugin-auth/src/auth-strategies/supabase/__tests__/admin/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/supabase/__tests__/admin/verify-callback.spec.ts
@@ -1,0 +1,198 @@
+import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import { Auth0AdminStrategy } from '../../admin';
+import { AUTH_PROVIDER_KEY } from '../../../../types';
+import { Auth0Options, AUTH0_ADMIN_STRATEGY_NAME, Profile, ExtraParams } from '../../types';
+
+describe('Auth0 admin strategy verify callback', function () {
+	const existsEmail = 'exists@test.fr';
+	const existsEmailWithProviderKey = 'exist3s@test.fr';
+	const existsEmailWithWrongProviderKey = 'exist4s@test.fr';
+
+	let container: MedusaContainer;
+	let req: Request;
+	let accessToken: string;
+	let refreshToken: string;
+	let profile: Profile;
+	let extraParams: ExtraParams;
+	let auth0AdminStrategy: Auth0AdminStrategy;
+
+	beforeEach(() => {
+		profile = {
+			emails: [{ value: existsEmail }],
+		};
+
+		extraParams = {};
+
+		container = {
+			resolve: (name: string) => {
+				const container_ = {
+					userService: {
+						retrieveByEmail: jest.fn().mockImplementation(async (email: string) => {
+							if (email === existsEmail) {
+								return {
+									id: 'test',
+								};
+							}
+
+							if (email === existsEmailWithProviderKey) {
+								return {
+									id: 'test2',
+									metadata: {
+										[AUTH_PROVIDER_KEY]: AUTH0_ADMIN_STRATEGY_NAME,
+									},
+								};
+							}
+
+							if (email === existsEmailWithWrongProviderKey) {
+								return {
+									id: 'test3',
+									metadata: {
+										[AUTH_PROVIDER_KEY]: 'fake_provider_key',
+									},
+								};
+							}
+
+							return;
+						}),
+					},
+				};
+
+				return container_[name];
+			},
+		} as MedusaContainer;
+	});
+
+	describe('when strict is set to admin', function () {
+		beforeEach(() => {
+			auth0AdminStrategy = new Auth0AdminStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					auth0Domain: 'fakeDomain',
+					clientID: 'fake',
+					clientSecret: 'fake',
+					admin: { callbackUrl: '/fakeCallbackUrl' },
+				} as Auth0Options,
+				'admin'
+			);
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithProviderKey }],
+			};
+
+			const data = await auth0AdminStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+		});
+
+		it('should fail when a user exists without the auth provider metadata', async () => {
+			profile = {
+				emails: [{ value: existsEmail }],
+			};
+
+			const err = await auth0AdminStrategy
+				.validate(req, accessToken, refreshToken, extraParams, profile)
+				.catch((err) => err);
+			expect(err).toEqual(new Error(`Admin with email ${existsEmail} already exists`));
+		});
+
+		it('should fail when a user exists with the wrong auth provider key', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithWrongProviderKey }],
+			};
+
+			const err = await auth0AdminStrategy
+				.validate(req, accessToken, refreshToken, extraParams, profile)
+				.catch((err) => err);
+			expect(err).toEqual(new Error(`Admin with email ${existsEmailWithWrongProviderKey} already exists`));
+		});
+
+		it('should fail when the user does not exist', async () => {
+			profile = {
+				emails: [{ value: 'fake' }],
+			};
+
+			const err = await auth0AdminStrategy
+				.validate(req, accessToken, refreshToken, extraParams, profile)
+				.catch((err) => err);
+			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
+		});
+	});
+
+	describe('when strict is set for store only', function () {
+		beforeEach(() => {
+			auth0AdminStrategy = new Auth0AdminStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					auth0Domain: 'fakeDomain',
+					clientID: 'fake',
+					clientSecret: 'fake',
+					admin: { callbackUrl: '/fakeCallbackUrl' },
+				} as Auth0Options,
+				'store'
+			);
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithProviderKey }],
+			};
+
+			const data = await auth0AdminStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+		});
+
+		it('should succeed when a user exists without the auth provider metadata', async () => {
+			profile = {
+				emails: [{ value: existsEmail }],
+			};
+
+			const data = await auth0AdminStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual({
+				accessToken: undefined,
+				id: 'test',
+			});
+		});
+
+		it('should succeed when a user exists with the wrong auth provider key', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithWrongProviderKey }],
+			};
+
+			const data = await auth0AdminStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual({
+				accessToken: undefined,
+				id: 'test3',
+			});
+		});
+
+		it('should fail when the user does not exist', async () => {
+			profile = {
+				emails: [{ value: 'fake' }],
+			};
+
+			const err = await auth0AdminStrategy
+				.validate(req, accessToken, refreshToken, extraParams, profile)
+				.catch((err) => err);
+			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
+		});
+	});
+});

--- a/packages/medusa-plugin-auth/src/auth-strategies/supabase/__tests__/store/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/supabase/__tests__/store/verify-callback.spec.ts
@@ -1,0 +1,274 @@
+import { Auth0StoreStrategy } from '../../store';
+import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import { AUTH_PROVIDER_KEY, CUSTOMER_METADATA_KEY } from '../../../../types';
+import { Auth0Options, AUTH0_STORE_STRATEGY_NAME, Profile, ExtraParams } from '../../types';
+
+describe('Auth0 store strategy verify callback', function () {
+	const existsEmail = 'exists@test.fr';
+	const existsEmailWithMeta = 'exist2s@test.fr';
+	const existsEmailWithMetaAndProviderKey = 'exist3s@test.fr';
+	const existsEmailWithMetaButWrongProviderKey = 'exist4s@test.fr';
+
+	let container: MedusaContainer;
+	let req: Request;
+	let accessToken: string;
+	let refreshToken: string;
+	let profile: Profile;
+	let extraParams: ExtraParams;
+	let auth0StoreStrategy: Auth0StoreStrategy;
+	let updateFn;
+	let createFn;
+
+	beforeEach(() => {
+		profile = {
+			emails: [{ value: existsEmail }],
+		};
+
+		extraParams = {};
+		updateFn = jest.fn().mockImplementation(async () => {
+			return { id: 'test' };
+		});
+		createFn = jest.fn().mockImplementation(async () => {
+			return { id: 'test' };
+		});
+
+		container = {
+			resolve: <T>(name: string): T => {
+				const container_ = {
+					manager: {
+						transaction: function (cb) {
+							return cb();
+						},
+					},
+					customerService: {
+						withTransaction: function () {
+							return this;
+						},
+						create: createFn,
+						update: updateFn,
+						retrieveRegisteredByEmail: jest.fn().mockImplementation(async (email: string) => {
+							if (email === existsEmail) {
+								return {
+									id: 'test',
+								};
+							}
+
+							if (email === existsEmailWithMeta) {
+								return {
+									id: 'test2',
+									metadata: {
+										[CUSTOMER_METADATA_KEY]: true,
+									},
+								};
+							}
+
+							if (email === existsEmailWithMetaAndProviderKey) {
+								return {
+									id: 'test3',
+									metadata: {
+										[CUSTOMER_METADATA_KEY]: true,
+										[AUTH_PROVIDER_KEY]: AUTH0_STORE_STRATEGY_NAME,
+									},
+								};
+							}
+
+							if (email === existsEmailWithMetaButWrongProviderKey) {
+								return {
+									id: 'test4',
+									metadata: {
+										[CUSTOMER_METADATA_KEY]: true,
+										[AUTH_PROVIDER_KEY]: 'fake_provider_key',
+									},
+								};
+							}
+
+							return;
+						}),
+					},
+				};
+
+				return container_[name];
+			},
+		} as MedusaContainer;
+	});
+
+	describe('when strict is set to store', function () {
+		beforeEach(() => {
+			auth0StoreStrategy = new Auth0StoreStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					auth0Domain: 'fakeDomain',
+					clientID: 'fake',
+					clientSecret: 'fake',
+					store: { callbackUrl: '/fakeCallbackUrl' },
+				} as Auth0Options,
+				'store'
+			);
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaAndProviderKey }],
+			};
+
+			const data = await auth0StoreStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				})
+			);
+		});
+
+		it('should fail when the customer exists without the metadata', async () => {
+			profile = {
+				emails: [{ value: existsEmail }],
+			};
+
+			const err = await auth0StoreStrategy
+				.validate(req, accessToken, refreshToken, extraParams, profile)
+				.catch((err) => err);
+			expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
+		});
+
+		it('should update customer metadata when the customer exsits with ONLY customer metadata key', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMeta }],
+			};
+
+			const data = await auth0StoreStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should fail when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
+			};
+
+			const err = await auth0StoreStrategy
+				.validate(req, accessToken, refreshToken, extraParams, profile)
+				.catch((err) => err);
+			expect(err).toEqual(
+				new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`)
+			);
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				emails: [{ value: 'fake' }],
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await auth0StoreStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('when strict is set to admin', function () {
+		beforeEach(() => {
+			auth0StoreStrategy = new Auth0StoreStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					auth0Domain: 'fakeDomain',
+					clientID: 'fake',
+					clientSecret: 'fake',
+					store: { callbackUrl: '/fakeCallbackUrl' },
+				} as Auth0Options,
+				'admin'
+			);
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaAndProviderKey }],
+			};
+
+			const data = await auth0StoreStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				})
+			);
+		});
+
+		it('should succeed when the customer exists without the metadata', async () => {
+			profile = {
+				emails: [{ value: existsEmail }],
+			};
+
+			const data = await auth0StoreStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+		});
+
+		it('should update customer metadata when the customer exsits with ONLY customer metadata key', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMeta }],
+			};
+
+			const data = await auth0StoreStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				})
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should succeed when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
+			};
+
+			const data = await auth0StoreStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test4',
+				})
+			);
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				emails: [{ value: 'fake' }],
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await auth0StoreStrategy.validate(req, accessToken, refreshToken, extraParams, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				})
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/medusa-plugin-auth/src/auth-strategies/supabase/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/supabase/admin.ts
@@ -1,0 +1,79 @@
+import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import { Router } from 'express';
+import { SUPABASE_AUTH_ADMIN_STRATEGY_NAME, SupabaseAuthOptions, Profile, ExtraParams } from './types';
+import { PassportStrategy } from '../../core/passport/Strategy';
+import { validateAdminCallback } from '../../core/validate-callback';
+import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { AuthOptions } from '../../types';
+import { createClient } from '@supabase/supabase-js';
+
+export class SupabaseAdminStrategy extends PassportStrategy(createClient, SUPABASE_AUTH_ADMIN_STRATEGY_NAME) {
+	constructor(
+		protected readonly container: MedusaContainer,
+		protected readonly configModule: ConfigModule,
+		protected readonly strategyOptions: SupabaseAuthOptions,
+		protected readonly strict?: AuthOptions['strict']
+	) {
+		super({
+			url: strategyOptions.supabaseUrl,
+			key: strategyOptions.supabaseKey,
+		});
+	}
+
+	async validate(
+		req: Request,
+		accessToken: string,
+		refreshToken: string,
+		extraParams: ExtraParams,
+		profile: Profile
+	): Promise<null | { id: string; accessToken: string }> {
+		if (this.strategyOptions.admin.verifyCallback) {
+			const validateRes = await this.strategyOptions.admin.verifyCallback(
+				this.container,
+				req,
+				accessToken,
+				refreshToken,
+				extraParams,
+				profile,
+				this.strict
+			);
+
+			return {
+				...validateRes,
+				accessToken,
+			};
+		}
+		const validateRes = await validateAdminCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: "supabase",
+			strict: this.strict,
+		});
+		return {
+			...validateRes,
+			accessToken,
+		};
+	}
+}
+
+/**
+ * Return the router that holds the supabase admin authentication routes
+ * @param supabase
+ * @param configModule
+ */
+export function getSupabaseAdminAuthRouter(supabase: SupabaseAuthOptions, configModule: ConfigModule): Router {
+	return passportAuthRoutesBuilder({
+		domain: 'admin',
+		configModule,
+		authPath: supabase.admin.authPath ?? '/admin/auth/supabase',
+		authCallbackPath: supabase.admin.authCallbackPath ?? '/admin/auth/supabase/cb',
+		successRedirect: supabase.admin.successRedirect,
+		strategyName: SUPABASE_AUTH_ADMIN_STRATEGY_NAME,
+		passportAuthenticateMiddlewareOptions: {
+			scope: 'openid email profile',
+		},
+		passportCallbackAuthenticateMiddlewareOptions: {
+			failureRedirect: supabase.admin.failureRedirect,
+		},
+		expiresIn: supabase.admin.expiresIn,
+	});
+}

--- a/packages/medusa-plugin-auth/src/auth-strategies/supabase/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/supabase/index.ts
@@ -1,0 +1,34 @@
+import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import { AuthOptions, StrategyExport } from '../../types';
+import { Router } from 'express';
+import { getSupabaseAdminAuthRouter, SupabaseAdminStrategy } from './admin';
+import { getSupabaseStoreAuthRouter, SupabaseStrategy } from './store';
+
+export * from './admin';
+export * from './store';
+export * from './types';
+
+export default {
+	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
+		if (options.supabase?.admin) {
+			new SupabaseStrategy(container, configModule, options.supabase, options.strict);
+		}
+
+		if (options.supabase?.store) {
+			new SupabaseStrategy(container, configModule, options.supabase, options.strict);
+		}
+	},
+	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {
+		const routers = [];
+
+		if (options.supabase?.admin) {
+			routers.push(getSupabaseAdminAuthRouter(options.supabase, configModule));
+		}
+
+		if (options.supabase?.store) {
+			routers.push(getSupabaseStoreAuthRouter(options.supabase, configModule));
+		}
+
+		return routers;
+	},
+} as StrategyExport;

--- a/packages/medusa-plugin-auth/src/auth-strategies/supabase/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/supabase/store.ts
@@ -1,0 +1,119 @@
+import { MedusaContainer } from '@medusajs/medusa/dist/types/global';
+
+export const SUPABASE_AUTH_ADMIN_STRATEGY_NAME = 'supabase-auth.admin.medusa-auth-plugin';
+export const SUPABASE_AUTH_STORE_STRATEGY_NAME = 'supabase-auth.store.medusa-auth-plugin';
+
+export type Profile = { email: string; name?: string };
+export type ExtraParams = {
+  audience?: string | undefined;
+  connection?: string | undefined;
+  prompt?: string | undefined;
+};
+
+export type SupabaseAuthOptions = {
+  supabaseUrl: string;
+  supabaseKey: string;
+  admin?: {
+    callbackUrl: string;
+    successRedirect: string;
+    failureRedirect: string;
+    authPath?: string;
+    authCallbackPath?: string;
+    verifyCallback?: (
+      container: MedusaContainer,
+      req: Request,
+      accessToken: string,
+      refreshToken: string,
+      extraParams: ExtraParams,
+      profile: Profile,
+    ) => Promise<null | { id: string } | never>;
+    expiresIn?: number;
+  };
+  store?: {
+    callbackUrl: string;
+    successRedirect: string;
+    failureRedirect: string;
+    authPath?: string;
+    authCallbackPath?: string;
+    verifyCallback?: (
+      container: MedusaContainer,
+      req: Request,
+      accessToken: string,
+      refreshToken: string,
+      extraParams: ExtraParams,
+      profile: Profile,
+    ) => Promise<null | { id: string } | never>;
+    expiresIn?: number;
+  };
+};
+
+import { Router } from 'express';
+import { ConfigModule } from '@medusajs/medusa/dist/types/global';
+import { PassportStrategy } from '../../core/passport/Strategy';
+import { validateStoreCallback } from '../../core/validate-callback';
+import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { ExtractJwt } from 'passport-jwt';
+import { SupabaseAuthStrategy } from 'nestjs-supabase-auth';
+
+export class SupabaseStrategy extends PassportStrategy(
+  SupabaseAuthStrategy,
+  'supabase',
+) {
+  public constructor() {
+    super({
+      supabaseUrl: process.env.SUPABASE_URL,
+      supabaseKey: process.env.SUPABASE_KEY,
+      supabaseOptions: {},
+      supabaseJwtSecret: process.env.SUPABASE_JWT_SECRET,
+      extractor: ExtractJwt.fromAuthHeaderAsBearerToken(),
+    });
+  }
+
+  async validate(
+    container: MedusaContainer,
+    req: Request,
+    accessToken: string,
+    refreshToken: string,
+    extraParams: ExtraParams,
+    profile: Profile,
+  ): Promise<null | { id: string } | never> {
+    return super.validate(
+      container,
+      req,
+      accessToken,
+      refreshToken,
+      extraParams,
+      profile,
+    );
+  }
+
+  authenticate(req) {
+    return super.authenticate(req);
+  }
+}
+
+export function getSupabaseStoreAuthRouter(
+  supabase: SupabaseAuthOptions,
+  configModule: ConfigModule
+): Router {
+  return passportAuthRoutesBuilder({
+    domain: 'store',
+    configModule,
+    authPath: supabase.store?.authPath ?? '/store/auth/supabase',
+    authCallbackPath: supabase.store?.authCallbackPath ?? '/store/auth/supabase/cb',
+    successRedirect: supabase.store.successRedirect,
+    strategy: new SupabaseAuthStrategy({
+      supabaseUrl: supabase.supabaseUrl,
+      supabaseKey: supabase.supabaseKey,
+      supabaseOptions: {},
+      // callbackURL: supabase.store.callbackUrl,
+    }),
+    passportAuthenticateMiddlewareOptions: {
+      scope: 'openid email profile',
+    },
+    passportCallbackAuthenticateMiddlewareOptions: {
+      failureRedirect: supabase.store.failureRedirect,
+    },
+    expiresIn: supabase.store.expiresIn,
+  });
+}

--- a/packages/medusa-plugin-auth/src/auth-strategies/supabase/types.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/supabase/types.ts
@@ -1,0 +1,71 @@
+import { MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import { AuthOptions } from '../../types';
+
+export const SUPABASE_AUTH_ADMIN_STRATEGY_NAME = 'supabase-auth.admin.medusa-auth-plugin';
+export const SUPABASE_AUTH_STORE_STRATEGY_NAME = 'supabase-auth.store.medusa-auth-plugin';
+
+export type Profile = { emails: { value: string }[]; name?: { givenName?: string; familyName?: string } };
+export type ExtraParams = {
+	audience?: string | undefined;
+	connection?: string | undefined;
+	prompt?: string | undefined;
+};
+
+export type SupabaseAuthOptions = {
+	supabaseUrl: string;
+	supabaseKey: string;
+	admin?: {
+		callbackUrl: string;
+		successRedirect: string;
+		failureRedirect: string;
+		/**
+		 * Default /admin/auth/supabase-auth
+		 */
+		authPath?: string;
+		/**
+		 * Default /admin/auth/supabase-auth/cb
+		 */
+		authCallbackPath?: string;
+		/**
+		 * The default verify callback function will be used if this configuration is not specified
+		 */
+		verifyCallback?: (
+			container: MedusaContainer,
+			req: Request,
+			accessToken: string,
+			refreshToken: string,
+			extraParams: ExtraParams,
+			profile: Profile,
+			strict?: AuthOptions['strict']
+		) => Promise<null | { id: string } | never>;
+
+		expiresIn?: number;
+	};
+	store?: {
+		callbackUrl: string;
+		successRedirect: string;
+		failureRedirect: string;
+		/**
+		 * Default /store/auth/supabase-auth
+		 */
+		authPath?: string;
+		/**
+		 * Default /store/auth/supabase-auth/cb
+		 */
+		authCallbackPath?: string;
+		/**
+		 * The default verify callback function will be used if this configuration is not specified
+		 */
+		verifyCallback?: (
+			container: MedusaContainer,
+			req: Request,
+			accessToken: string,
+			refreshToken: string,
+			extraParams: ExtraParams,
+			profile: Profile,
+			strict?: AuthOptions['strict']
+		) => Promise<null | { id: string } | never>;
+
+		expiresIn?: number;
+	};
+};

--- a/packages/medusa-plugin-auth/src/types/index.ts
+++ b/packages/medusa-plugin-auth/src/types/index.ts
@@ -18,6 +18,7 @@ import {
 } from '../auth-strategies/linkedin';
 import { Auth0Options, AUTH0_ADMIN_STRATEGY_NAME, AUTH0_STORE_STRATEGY_NAME } from '../auth-strategies/auth0';
 import { AzureAuthOptions, AZURE_ADMIN_STRATEGY_NAME, AZURE_STORE_STRATEGY_NAME } from '../auth-strategies/azure-oidc';
+import { SupabaseAuthOptions, SUPABASE_AUTH_ADMIN_STRATEGY_NAME, SUPABASE_AUTH_STORE_STRATEGY_NAME } from '../auth-strategies/supaba';
 
 export const CUSTOMER_METADATA_KEY = 'useSocialAuth';
 export const AUTH_PROVIDER_KEY = 'authProvider';
@@ -49,6 +50,7 @@ export type ProviderOptions = {
 	linkedin?: LinkedinAuthOptions;
 	firebase?: FirebaseAuthOptions;
 	auth0?: Auth0Options;
+	supabase?: SupabaseAuthOptions;
 	azure_oidc?: AzureAuthOptions;
 };
 
@@ -84,5 +86,9 @@ export const strategyNames: StrategyNames = {
 	azure_oidc: {
 		admin: AZURE_ADMIN_STRATEGY_NAME,
 		store: AZURE_STORE_STRATEGY_NAME,
+	},
+	supabase: {
+		admin: SUPABASE_AUTH_ADMIN_STRATEGY_NAME,
+		store: SUPABASE_AUTH_STORE_STRATEGY_NAME,
 	},
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -13632,6 +13632,11 @@ neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+nestjs-supabase-auth@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/nestjs-supabase-auth/-/nestjs-supabase-auth-1.0.9.tgz#c530961e6575a989a2a4b269db27fc35732a8f9a"
+  integrity sha512-1Aar5K2WuGggPV8q/xzJCIeAQz5wkPcvKGLPTUXwt1he1EKLg+OdWK2C0T7LzTgO4uX2WLakNWZBsUTZEOvt4Q==
+
 netrc-parser@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/netrc-parser/-/netrc-parser-3.1.6.tgz#7243c9ec850b8e805b9bdc7eae7b1450d4a96e72"


### PR DESCRIPTION
WIP

Goal:
- Add supabase-auth strategy to medusa-plugin-auth based off auth0 current implementation.
- Reuse nestjs-passport-supabase strategies available from NPM if possible.

