### PR TITLE
Compatibility with Medusa 1.17 sessions

### DIFF
--- a/packages/medusa-plugin-auth/src/auth-strategies/firebase/utils.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/firebase/utils.ts
@@ -2,12 +2,11 @@ import passport from 'passport';
 import cors from 'cors';
 import { ConfigModule } from '@medusajs/medusa/dist/types/global';
 import { Router } from 'express';
-import { TWENTY_FOUR_HOURS_IN_MS } from '../../types';
-import { sendTokenFactory } from '../../core/auth-callback-middleware';
+import { authenticateSession } from '../../core/auth-callback-middleware';
 
-function firebaseCallbackMiddleware(domain: 'admin' | 'store', secret: string, expiresIn: number) {
+function firebaseCallbackMiddleware(domain: 'admin' | 'store') {
 	return (req, res) => {
-		const sendToken = sendTokenFactory(domain, secret, expiresIn);
+		const sendToken = authenticateSession(domain);
 		sendToken(req, res);
 		res.status(200).json({ result: 'OK' });
 	};
@@ -40,11 +39,7 @@ export function firebaseAuthRoutesBuilder({
 	/*necessary if you are using non medusajs client such as a pure axios call, axios initially requests options and then get*/
 	router.options(authPath, cors(corsOptions));
 
-	const callbackHandler = firebaseCallbackMiddleware(
-		domain,
-		configModule.projectConfig.jwt_secret,
-		expiresIn ?? TWENTY_FOUR_HOURS_IN_MS
-	);
+	const callbackHandler = firebaseCallbackMiddleware(domain);
 
 	router.get(
 		authPath,

--- a/packages/medusa-plugin-auth/src/core/auth-callback-middleware.ts
+++ b/packages/medusa-plugin-auth/src/core/auth-callback-middleware.ts
@@ -1,5 +1,3 @@
-import jwt from 'jsonwebtoken';
-
 /**
  * Return the handler of the auth callback for an auth strategy. Once the auth is successful this callback
  * will be called.
@@ -10,23 +8,19 @@ import jwt from 'jsonwebtoken';
  */
 export function authCallbackMiddleware(
 	domain: 'admin' | 'store',
-	secret: string,
-	expiresIn: number,
 	successRedirectGetter: () => string
 ) {
 	return (req, res) => {
-		const sendToken = sendTokenFactory(domain, secret, expiresIn);
+		const sendToken = authenticateSession(domain);
 		sendToken(req, res);
 		res.redirect(successRedirectGetter());
 	};
 }
 
-export function sendTokenFactory(domain: 'admin' | 'store', secret: string, expiresIn: number) {
+export function authenticateSession(domain: 'admin' | 'store') {
 	return (req, res) => {
-		const tokenData =
-			domain === 'admin' ? { userId: req.user.id, ...req.user } : { customer_id: req.user.id, ...req.user };
-		const token = jwt.sign(tokenData, secret, { expiresIn });
-		const sessionKey = domain === 'admin' ? 'jwt' : 'jwt_store';
-		req.session[sessionKey] = token;
+		const sessionKey = domain === 'admin' ? 'user_id': 'customer_id';
+
+		req.session[sessionKey] = req.user.id;
 	};
 }

--- a/packages/medusa-plugin-auth/src/core/passport/utils/auth-routes-builder.ts
+++ b/packages/medusa-plugin-auth/src/core/passport/utils/auth-routes-builder.ts
@@ -1,13 +1,12 @@
 import { Router } from 'express';
 import passport from 'passport';
 import cors from 'cors';
-import { TWENTY_FOUR_HOURS_IN_MS } from '../../../types';
 import { authCallbackMiddleware } from '../../auth-callback-middleware';
 import { ConfigModule } from '@medusajs/medusa/dist/types/global';
 
 type PassportAuthenticateMiddlewareOptions = {
 	[key: string]: unknown;
-	scope?: unknown;
+	scope?: string | string[];
 };
 
 type PassportCallbackAuthenticateMiddlewareOptions = {
@@ -78,8 +77,6 @@ export function passportAuthRoutesBuilder({
 
 	const callbackHandler = authCallbackMiddleware(
 		domain,
-		configModule.projectConfig.jwt_secret,
-		expiresIn ?? TWENTY_FOUR_HOURS_IN_MS,
 		() => successRedirect
 	);
 


### PR DESCRIPTION
Update to work with 1.17 sessions.

IMPORTANT: this breaks the expiresIn argument, as sessions don't expire in Medusa. A further update to Medusa core is required to set configurable expiry time on cookies and JWT tokens. This is also planned.

Supporting Bearer Auth using current structure is non-trivial, as auth strategies return status 30x (redirect).