### PR TITLE
fix: generate random password the first time

### DIFF
--- a/packages/medusa-plugin-auth/src/core/passport/utils/auth-routes-builder.ts
+++ b/packages/medusa-plugin-auth/src/core/passport/utils/auth-routes-builder.ts
@@ -99,7 +99,9 @@ export function passportAuthRoutesBuilder({
 					if (options?.msg) {
 						if (passportCallbackAuthenticateMiddlewareOptions?.failureRedirect) {
 							return res.redirect(
-								passportCallbackAuthenticateMiddlewareOptions.failureRedirect + '?message=' + options.msg
+								passportCallbackAuthenticateMiddlewareOptions.failureRedirect +
+									'?message=' +
+									options.msg
 							);
 						} else {
 							return res.status(401).json({ message: options.msg });
@@ -115,7 +117,13 @@ export function passportAuthRoutesBuilder({
 	return router;
 }
 
-function successActionHandlerFactory(req: Request, domain: 'admin' | 'store', configModule: ConfigModule, defaultRedirect: string, expiresIn?: number) {
+function successActionHandlerFactory(
+	req: Request,
+	domain: 'admin' | 'store',
+	configModule: ConfigModule,
+	defaultRedirect: string,
+	expiresIn?: number
+) {
 	const returnAccessToken = req.query.returnAccessToken == 'true';
 	const redirectUrl = (req.query.redirectTo ? req.query.redirectTo : defaultRedirect) as string;
 
@@ -131,7 +139,6 @@ function successActionHandlerFactory(req: Request, domain: 'admin' | 'store', co
 		authenticateSession(req, res);
 
 		const token = signToken(domain, configModule, req.user, expiresIn);
-
 
 		// append token to redirect url as query param
 		const url = new URL(redirectUrl);

--- a/packages/medusa-plugin-auth/src/core/validate-callback.ts
+++ b/packages/medusa-plugin-auth/src/core/validate-callback.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { CustomerService, UserService } from '@medusajs/medusa';
 import { MedusaContainer } from '@medusajs/medusa/dist/types/global';
 import { MedusaError } from 'medusa-core-utils';
@@ -149,6 +150,13 @@ export async function validateStoreCallback<
 			}
 		}
 
+		const generatePassword = () => {
+			const characters = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz~!@-#$';
+			return Array.from(crypto.randomFillSync(new Uint32Array(20)))
+				.map((x) => characters[x % characters.length])
+				.join('');
+		};
+
 		customer = await customerService.withTransaction(transactionManager).create({
 			email,
 			metadata: {
@@ -159,6 +167,7 @@ export async function validateStoreCallback<
 			first_name: profile.name?.givenName ?? '',
 			last_name: profile.name?.familyName ?? '',
 			has_account: true,
+			password: generatePassword(),
 		});
 
 		return { id: customer.id };


### PR DESCRIPTION
**What**
When a customer has a guest account, if the customer tries to log in with an external provider it is currently throwing cause no password has been provided and a guest account exists. Now, when calling the create, we provide a randomly generated password that the user can reset later if he wants to use the default login flow.

wdyt @tsvetann ?