### PR TITLE
Feature/add steam passport

### DIFF
--- a/packages/medusa-plugin-auth/package.json
+++ b/packages/medusa-plugin-auth/package.json
@@ -55,6 +55,7 @@
     "@types/express": "^4.17.17",
     "@types/jest": "^29.1.2",
     "@types/passport-oauth2": "^1.4.15",
+    "@types/passport-steam": "^1.0.4",
     "jest": "^29.1.2",
     "passport": "^0.6.0",
     "ts-jest": "^29.0.3",
@@ -74,7 +75,8 @@
     "passport-firebase-jwt": "^1.2.1",
     "passport-google-oauth2": "^0.2.0",
     "passport-linkedin-oauth2": "^2.0.0",
-    "passport-oauth2": "^1.7.0"
+    "passport-oauth2": "^1.7.0",
+    "passport-steam": "^1.0.18"
   },
   "jest": {
     "preset": "ts-jest",

--- a/packages/medusa-plugin-auth/src/api/index.ts
+++ b/packages/medusa-plugin-auth/src/api/index.ts
@@ -8,6 +8,7 @@ import LinkedinStrategy from '../auth-strategies/linkedin';
 import FirebaseStrategy from '../auth-strategies/firebase';
 import Auth0Strategy from '../auth-strategies/auth0';
 import AzureStrategy from '../auth-strategies/azure-oidc';
+import SteamStrategy from '../auth-strategies/steam';
 
 import { AuthOptions } from '../types';
 
@@ -26,6 +27,7 @@ function loadRouters(configModule: ConfigModule, options: AuthOptions): Router[]
 	routers.push(...FirebaseStrategy.getRouter(configModule, options));
 	routers.push(...Auth0Strategy.getRouter(configModule, options));
 	routers.push(...AzureStrategy.getRouter(configModule, options));
+	routers.push(...SteamStrategy.getRouter(configModule, options));
 
 	return routers;
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/steam/__tests__/admin/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/steam/__tests__/admin/verify-callback.spec.ts
@@ -1,0 +1,191 @@
+import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import { SteamAdminStrategy } from '../../admin';
+import { AUTH_PROVIDER_KEY } from '../../../../types';
+import { STEAM_ADMIN_STRATEGY_NAME, SteamAuthOptions } from '../../types';
+
+describe('Steam admin strategy verify callback', function() {
+	const existsEmail = 'exists@test.fr';
+	const existsEmailWithProviderKey = 'exist3s@test.fr';
+	const existsEmailWithWrongProviderKey = 'exist4s@test.fr';
+
+	let container: MedusaContainer;
+	let req: Request;
+	let accessToken: string;
+	let refreshToken: string;
+	let profile: { emails: { value: string }[]; name?: { givenName?: string; familyName?: string } };
+	let steamAdminStrategy: SteamAdminStrategy;
+
+	beforeEach(() => {
+		profile = {
+			emails: [{ value: existsEmail }],
+		};
+
+		container = {
+			resolve: (name: string) => {
+				const container_ = {
+					userService: {
+						retrieveByEmail: jest.fn().mockImplementation(async (email: string) => {
+							if (email === existsEmail) {
+								return {
+									id: 'test',
+								};
+							}
+
+							if (email === existsEmailWithProviderKey) {
+								return {
+									id: 'test2',
+									metadata: {
+										[AUTH_PROVIDER_KEY]: STEAM_ADMIN_STRATEGY_NAME,
+									},
+								};
+							}
+
+							if (email === existsEmailWithWrongProviderKey) {
+								return {
+									id: 'test3',
+									metadata: {
+										[AUTH_PROVIDER_KEY]: 'fake_provider_key',
+									},
+								};
+							}
+
+							return;
+						}),
+					},
+				};
+
+				return container_[name];
+			},
+		} as MedusaContainer;
+	});
+
+	describe('when strict is set to admin', function() {
+		beforeEach(() => {
+			steamAdminStrategy = new SteamAdminStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					realm: 'http://localhost',
+					apiKey: 'fake',
+					admin: {
+						callbackUrl: 'http://localhost',
+					},
+				} as SteamAuthOptions,
+				'admin',
+			);
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithProviderKey }],
+			};
+
+			const data = await steamAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				}),
+			);
+		});
+
+		it('should fail when a user exists without the auth provider metadata', async () => {
+			profile = {
+				emails: [{ value: existsEmail }],
+			};
+
+			const err = await steamAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Admin with email ${existsEmail} already exists`));
+		});
+
+		it('should fail when a user exists with the wrong auth provider key', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithWrongProviderKey }],
+			};
+
+			const err = await steamAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Admin with email ${existsEmailWithWrongProviderKey} already exists`));
+		});
+
+		it('should fail when the user does not exist', async () => {
+			profile = {
+				emails: [{ value: 'fake' }],
+			};
+
+			const err = await steamAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
+		});
+	});
+
+	describe('when strict is set for store only', function() {
+		beforeEach(() => {
+			steamAdminStrategy = new SteamAdminStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					realm: 'http://localhost',
+					apiKey: 'fake',
+					admin: {
+						callbackUrl: 'http://localhost',
+					},
+				} as SteamAuthOptions,
+				'store',
+			);
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithProviderKey }],
+			};
+
+			const data = await steamAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				}),
+			);
+		});
+
+		it('should succeed when a user exists without the auth provider metadata', async () => {
+			profile = {
+				emails: [{ value: existsEmail }],
+			};
+
+			const data = await steamAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				}),
+			);
+		});
+
+		it('should succeed when a user exists with the wrong auth provider key', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithWrongProviderKey }],
+			};
+
+			const data = await steamAdminStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				}),
+			);
+		});
+
+		it('should fail when the user does not exist', async () => {
+			profile = {
+				emails: [{ value: 'fake' }],
+			};
+
+			const err = await steamAdminStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Unable to authenticate the user with the email fake`));
+		});
+	});
+});

--- a/packages/medusa-plugin-auth/src/auth-strategies/steam/__tests__/store/verify-callback.spec.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/steam/__tests__/store/verify-callback.spec.ts
@@ -1,0 +1,270 @@
+import { SteamStoreStrategy } from '../../store';
+import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import { AUTH_PROVIDER_KEY, CUSTOMER_METADATA_KEY } from '../../../../types';
+import { Profile, STEAM_STORE_STRATEGY_NAME, SteamAuthOptions } from '../../types';
+
+describe('Steam store strategy verify callback', function() {
+	const existsEmail = 'exists@test.fr';
+	const existsEmailWithMeta = 'exist2s@test.fr';
+	const existsEmailWithMetaAndProviderKey = 'exist3s@test.fr';
+	const existsEmailWithMetaButWrongProviderKey = 'exist4s@test.fr';
+
+	let container: MedusaContainer;
+	let req: Request;
+	let accessToken: string;
+	let refreshToken: string;
+	let profile: Profile;
+	let steamStoreStrategy: SteamStoreStrategy;
+	let updateFn;
+	let createFn;
+
+	beforeEach(() => {
+		profile = {
+			emails: [{ value: existsEmail }],
+		};
+
+		updateFn = jest.fn().mockImplementation(async () => {
+			return { id: 'test' };
+		});
+		createFn = jest.fn().mockImplementation(async () => {
+			return { id: 'test' };
+		});
+
+		container = {
+			resolve: <T>(name: string): T => {
+				const container_ = {
+					manager: {
+						transaction: function(cb) {
+							return cb();
+						},
+					},
+					customerService: {
+						withTransaction: function() {
+							return this;
+						},
+						update: updateFn,
+						create: createFn,
+						retrieveRegisteredByEmail: jest.fn().mockImplementation(async (email: string) => {
+							if (email === existsEmail) {
+								return {
+									id: 'test',
+								};
+							}
+
+							if (email === existsEmailWithMeta) {
+								return {
+									id: 'test2',
+									metadata: {
+										[CUSTOMER_METADATA_KEY]: true,
+									},
+								};
+							}
+
+							if (email === existsEmailWithMetaAndProviderKey) {
+								return {
+									id: 'test3',
+									metadata: {
+										[CUSTOMER_METADATA_KEY]: true,
+										[AUTH_PROVIDER_KEY]: STEAM_STORE_STRATEGY_NAME,
+									},
+								};
+							}
+
+							if (email === existsEmailWithMetaButWrongProviderKey) {
+								return {
+									id: 'test4',
+									metadata: {
+										[CUSTOMER_METADATA_KEY]: true,
+										[AUTH_PROVIDER_KEY]: 'fake_provider_key',
+									},
+								};
+							}
+
+							return;
+						}),
+					},
+				};
+
+				return container_[name];
+			},
+		} as MedusaContainer;
+	});
+
+	describe('when strict is set to store', function() {
+		beforeEach(() => {
+			steamStoreStrategy = new SteamStoreStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					realm: 'http://localhost',
+					apiKey: 'fake',
+					store: {
+						callbackUrl: 'http://localhost',
+					},
+				} as SteamAuthOptions,
+				'store',
+			);
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaAndProviderKey }],
+			};
+
+			const data = await steamStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				}),
+			);
+		});
+
+		it('should fail when the customer exists without the metadata', async () => {
+			profile = {
+				emails: [{ value: existsEmail }],
+			};
+
+			const err = await steamStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(new Error(`Customer with email ${existsEmail} already exists`));
+		});
+
+		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMeta }],
+			};
+
+			const data = await steamStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				}),
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should fail when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
+			};
+
+			const err = await steamStoreStrategy.validate(req, accessToken, refreshToken, profile).catch((err) => err);
+			expect(err).toEqual(
+				new Error(`Customer with email ${existsEmailWithMetaButWrongProviderKey} already exists`),
+			);
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				emails: [{ value: 'fake' }],
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await steamStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				}),
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('when strict is set to admin only', function() {
+		beforeEach(() => {
+			steamStoreStrategy = new SteamStoreStrategy(
+				container,
+				{} as ConfigModule,
+				{
+					realm: 'http://localhost',
+					apiKey: 'fake',
+					store: {
+						callbackUrl: 'http://localhost',
+					},
+				} as SteamAuthOptions,
+				'admin',
+			);
+		});
+
+		afterEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('should succeed', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaAndProviderKey }],
+			};
+
+			const data = await steamStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test3',
+				}),
+			);
+		});
+
+		it('should succeed when the customer exists without the metadata', async () => {
+			profile = {
+				emails: [{ value: existsEmail }],
+			};
+
+			const data = await steamStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				}),
+			);
+		});
+
+		it('should set AUTH_PROVIDER_KEY when CUSTOMER_METADATA_KEY exists but AUTH_PROVIDER_KEY does not', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMeta }],
+			};
+
+			const data = await steamStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test2',
+				}),
+			);
+			expect(updateFn).toHaveBeenCalledTimes(1);
+		});
+
+		it('should succeed when the metadata exists but auth provider key is wrong', async () => {
+			profile = {
+				emails: [{ value: existsEmailWithMetaButWrongProviderKey }],
+			};
+
+			const data = await steamStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test4',
+				}),
+			);
+		});
+
+		it('should succeed and create a new customer if it has not been found', async () => {
+			profile = {
+				emails: [{ value: 'fake' }],
+				name: {
+					givenName: 'test',
+					familyName: 'test',
+				},
+			};
+
+			const data = await steamStoreStrategy.validate(req, accessToken, refreshToken, profile);
+			expect(data).toEqual(
+				expect.objectContaining({
+					id: 'test',
+				}),
+			);
+			expect(createFn).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/medusa-plugin-auth/src/auth-strategies/steam/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/steam/admin.ts
@@ -1,0 +1,70 @@
+import {Strategy as SteamStrategy} from 'passport-steam';
+import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import { Router } from 'express';
+import { STEAM_ADMIN_STRATEGY_NAME, SteamAuthOptions, Profile } from './types';
+import { PassportStrategy } from '../../core/passport/Strategy';
+import { validateAdminCallback } from '../../core/validate-callback';
+import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { AuthOptions } from '../../types';
+
+export class SteamAdminStrategy extends PassportStrategy(SteamStrategy, STEAM_ADMIN_STRATEGY_NAME) {
+
+	constructor(
+		protected readonly container: MedusaContainer,
+		protected readonly configModule: ConfigModule,
+		protected readonly strategyOptions: SteamAuthOptions,
+		protected readonly strict?: AuthOptions['strict']
+	) {
+		super({
+			returnURL: strategyOptions.admin.callbackUrl,
+			realm: strategyOptions.realm,
+			apiKey: strategyOptions.apiKey,
+			passReqToCallback: true,
+		});
+	}
+
+	async validate(
+		req: Request,
+		accessToken: string,
+		refreshToken: string,
+		profile: Profile
+	): Promise<null | { id: string }> {
+		if (this.strategyOptions.admin.verifyCallback) {
+			return await this.strategyOptions.admin.verifyCallback(
+				this.container,
+				req,
+				accessToken,
+				refreshToken,
+				profile,
+				this.strict
+			);
+		}
+
+		return await validateAdminCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: 'steam',
+			strict: this.strict,
+		});
+	}
+}
+
+/**
+ * Return the router that hold the steam admin authentication routes
+ * @param steam
+ * @param configModule
+ */
+export function getSteamAdminAuthRouter(steam: SteamAuthOptions, configModule: ConfigModule): Router {
+	return passportAuthRoutesBuilder({
+		domain: 'admin',
+		configModule,
+		authPath: steam.admin.authPath ?? '/admin/auth/steam',
+		authCallbackPath: steam.admin.authCallbackPath ?? '/admin/auth/steam/cb',
+		successRedirect: steam.admin.successRedirect,
+		strategyName: STEAM_ADMIN_STRATEGY_NAME,
+		passportAuthenticateMiddlewareOptions: {},
+		passportCallbackAuthenticateMiddlewareOptions: {
+			failureRedirect: steam.admin.failureRedirect,
+		},
+		expiresIn: steam.admin.expiresIn,
+	});
+}

--- a/packages/medusa-plugin-auth/src/auth-strategies/steam/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/steam/admin.ts
@@ -1,7 +1,7 @@
-import {Strategy as SteamStrategy} from 'passport-steam';
+import { Strategy as SteamStrategy } from 'passport-steam';
 import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
 import { Router } from 'express';
-import { STEAM_ADMIN_STRATEGY_NAME, SteamAuthOptions, Profile } from './types';
+import { Profile, STEAM_ADMIN_STRATEGY_NAME, SteamAuthOptions } from './types';
 import { PassportStrategy } from '../../core/passport/Strategy';
 import { validateAdminCallback } from '../../core/validate-callback';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
@@ -13,7 +13,7 @@ export class SteamAdminStrategy extends PassportStrategy(SteamStrategy, STEAM_AD
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: SteamAuthOptions,
-		protected readonly strict?: AuthOptions['strict']
+		protected readonly strict?: AuthOptions['strict'],
 	) {
 		super({
 			returnURL: strategyOptions.admin.callbackUrl,
@@ -25,18 +25,16 @@ export class SteamAdminStrategy extends PassportStrategy(SteamStrategy, STEAM_AD
 
 	async validate(
 		req: Request,
-		accessToken: string,
-		refreshToken: string,
-		profile: Profile
+		identifier: string,
+		profile: Profile,
 	): Promise<null | { id: string }> {
 		if (this.strategyOptions.admin.verifyCallback) {
 			return await this.strategyOptions.admin.verifyCallback(
 				this.container,
 				req,
-				accessToken,
-				refreshToken,
+				identifier,
 				profile,
-				this.strict
+				this.strict,
 			);
 		}
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/steam/index.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/steam/index.ts
@@ -1,0 +1,34 @@
+import { AuthOptions, StrategyExport } from '../../types';
+import { Router } from 'express';
+import { getSteamAdminAuthRouter, SteamAdminStrategy } from './admin';
+import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import { getSteamStoreAuthRouter, SteamStoreStrategy } from './store';
+
+export * from './types';
+export * from './admin';
+export * from './store';
+
+export default {
+	load: (container: MedusaContainer, configModule: ConfigModule, options: AuthOptions): void => {
+		if (options.steam?.admin) {
+			new SteamAdminStrategy(container, configModule, options.steam, options.strict);
+		}
+
+		if (options.steam?.store) {
+			new SteamStoreStrategy(container, configModule, options.steam, options.strict);
+		}
+	},
+	getRouter: (configModule: ConfigModule, options: AuthOptions): Router[] => {
+		const routers = [];
+
+		if (options.steam?.admin) {
+			routers.push(getSteamAdminAuthRouter(options.steam, configModule));
+		}
+
+		if (options.steam?.store) {
+			routers.push(getSteamStoreAuthRouter(options.steam, configModule));
+		}
+
+		return routers;
+	},
+} as StrategyExport;

--- a/packages/medusa-plugin-auth/src/auth-strategies/steam/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/steam/store.ts
@@ -1,8 +1,8 @@
 import { Router } from 'express';
 import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
-import {Strategy as SteamStrategy} from 'passport-steam';
+import { Strategy as SteamStrategy } from 'passport-steam';
 import { PassportStrategy } from '../../core/passport/Strategy';
-import { STEAM_STORE_STRATEGY_NAME, SteamAuthOptions, Profile } from './types';
+import { Profile, STEAM_STORE_STRATEGY_NAME, SteamAuthOptions } from './types';
 import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
 import { validateStoreCallback } from '../../core/validate-callback';
 import { AuthOptions } from '../../types';
@@ -12,7 +12,7 @@ export class SteamStoreStrategy extends PassportStrategy(SteamStrategy, STEAM_ST
 		protected readonly container: MedusaContainer,
 		protected readonly configModule: ConfigModule,
 		protected readonly strategyOptions: SteamAuthOptions,
-		protected readonly strict?: AuthOptions['strict']
+		protected readonly strict?: AuthOptions['strict'],
 	) {
 		super({
 			returnURL: strategyOptions.store.callbackUrl,
@@ -24,18 +24,16 @@ export class SteamStoreStrategy extends PassportStrategy(SteamStrategy, STEAM_ST
 
 	async validate(
 		req: Request,
-		accessToken: string,
-		refreshToken: string,
-		profile: Profile
+		identifier: string,
+		profile: Profile,
 	): Promise<null | { id: string }> {
 		if (this.strategyOptions.store.verifyCallback) {
 			return await this.strategyOptions.store.verifyCallback(
 				this.container,
 				req,
-				accessToken,
-				refreshToken,
+				identifier,
 				profile,
-				this.strict
+				this.strict,
 			);
 		}
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/steam/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/steam/store.ts
@@ -1,0 +1,69 @@
+import { Router } from 'express';
+import { ConfigModule, MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import {Strategy as SteamStrategy} from 'passport-steam';
+import { PassportStrategy } from '../../core/passport/Strategy';
+import { STEAM_STORE_STRATEGY_NAME, SteamAuthOptions, Profile } from './types';
+import { passportAuthRoutesBuilder } from '../../core/passport/utils/auth-routes-builder';
+import { validateStoreCallback } from '../../core/validate-callback';
+import { AuthOptions } from '../../types';
+
+export class SteamStoreStrategy extends PassportStrategy(SteamStrategy, STEAM_STORE_STRATEGY_NAME) {
+	constructor(
+		protected readonly container: MedusaContainer,
+		protected readonly configModule: ConfigModule,
+		protected readonly strategyOptions: SteamAuthOptions,
+		protected readonly strict?: AuthOptions['strict']
+	) {
+		super({
+			returnURL: strategyOptions.store.callbackUrl,
+			realm: strategyOptions.realm,
+			apiKey: strategyOptions.apiKey,
+			passReqToCallback: true,
+		});
+	}
+
+	async validate(
+		req: Request,
+		accessToken: string,
+		refreshToken: string,
+		profile: Profile
+	): Promise<null | { id: string }> {
+		if (this.strategyOptions.store.verifyCallback) {
+			return await this.strategyOptions.store.verifyCallback(
+				this.container,
+				req,
+				accessToken,
+				refreshToken,
+				profile,
+				this.strict
+			);
+		}
+
+		return await validateStoreCallback(profile, {
+			container: this.container,
+			strategyErrorIdentifier: 'steam',
+			strict: this.strict,
+		});
+	}
+}
+
+/**
+ * Return the router that hold the steam store authentication routes
+ * @param steam
+ * @param configModule
+ */
+export function getSteamStoreAuthRouter(steam: SteamAuthOptions, configModule: ConfigModule): Router {
+	return passportAuthRoutesBuilder({
+		domain: 'store',
+		configModule,
+		authPath: steam.store.authPath ?? '/store/auth/steam',
+		authCallbackPath: steam.store.authCallbackPath ?? '/store/auth/steam/cb',
+		successRedirect: steam.store.successRedirect,
+		strategyName: STEAM_STORE_STRATEGY_NAME,
+		passportAuthenticateMiddlewareOptions: {},
+		passportCallbackAuthenticateMiddlewareOptions: {
+			failureRedirect: steam.store.failureRedirect,
+		},
+		expiresIn: steam.store.expiresIn,
+	});
+}

--- a/packages/medusa-plugin-auth/src/auth-strategies/steam/types.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/steam/types.ts
@@ -1,0 +1,64 @@
+import { MedusaContainer } from '@medusajs/medusa/dist/types/global';
+import { AuthOptions } from '../../types';
+
+export const STEAM_STORE_STRATEGY_NAME = 'steam.store.medusa-auth-plugin';
+export const STEAM_ADMIN_STRATEGY_NAME = 'steam.admin.medusa-auth-plugin';
+
+export type Profile = { emails: { value: string }[]; name?: { givenName?: string; familyName?: string } };
+
+export type SteamAuthOptions = {
+	realm: string;
+	apiKey: string;
+	admin?: {
+		callbackUrl: string;
+		successRedirect: string;
+		failureRedirect: string;
+		/**
+		 * Default /admin/auth/steam
+		 */
+		authPath?: string;
+		/**
+		 * Default /admin/auth/steam/cb
+		 */
+		authCallbackPath?: string;
+		/**
+		 * The default verify callback function will be used if this configuration is not specified
+		 */
+		verifyCallback?: (
+			container: MedusaContainer,
+			req: Request,
+			accessToken: string,
+			refreshToken: string,
+			profile: Profile,
+			strict?: AuthOptions['strict']
+		) => Promise<null | { id: string } | never>;
+
+		expiresIn?: number;
+	};
+	store?: {
+		callbackUrl: string;
+		successRedirect: string;
+		failureRedirect: string;
+		/**
+		 * Default /store/auth/steam
+		 */
+		authPath?: string;
+		/**
+		 * Default /store/auth/steam/cb
+		 */
+		authCallbackPath?: string;
+		/**
+		 * The default verify callback function will be used if this configuration is not specified
+		 */
+		verifyCallback?: (
+			container: MedusaContainer,
+			req: Request,
+			accessToken: string,
+			refreshToken: string,
+			profile: Profile,
+			strict?: AuthOptions['strict']
+		) => Promise<null | { id: string } | never>;
+
+		expiresIn?: number;
+	};
+};

--- a/packages/medusa-plugin-auth/src/auth-strategies/steam/types.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/steam/types.ts
@@ -4,7 +4,24 @@ import { AuthOptions } from '../../types';
 export const STEAM_STORE_STRATEGY_NAME = 'steam.store.medusa-auth-plugin';
 export const STEAM_ADMIN_STRATEGY_NAME = 'steam.admin.medusa-auth-plugin';
 
-export type Profile = { emails: { value: string }[]; name?: { givenName?: string; familyName?: string } };
+/**
+ * The profile returned from the steam strategy
+ *
+ * @see https://github.com/liamcurry/passport-steam/blob/master/lib/passport-steam/strategy.js#L30
+ *
+ * @param provider - The provider name
+ * @param id - The steam id
+ * @param _json - The raw json returned from steam
+ * @param displayName - The display name of the user
+ * @param photos - The photos of the user
+ */
+export type Profile = {
+	provider: 'steam';
+	id: string;
+	_json: any,
+	displayName?: string;
+	photos?: { value: string }[];
+};
 
 export type SteamAuthOptions = {
 	realm: string;
@@ -27,10 +44,9 @@ export type SteamAuthOptions = {
 		verifyCallback?: (
 			container: MedusaContainer,
 			req: Request,
-			accessToken: string,
-			refreshToken: string,
+			identifier: string,
 			profile: Profile,
-			strict?: AuthOptions['strict']
+			strict?: AuthOptions['strict'],
 		) => Promise<null | { id: string } | never>;
 
 		expiresIn?: number;
@@ -53,10 +69,9 @@ export type SteamAuthOptions = {
 		verifyCallback?: (
 			container: MedusaContainer,
 			req: Request,
-			accessToken: string,
-			refreshToken: string,
+			identifier: string,
 			profile: Profile,
-			strict?: AuthOptions['strict']
+			strict?: AuthOptions['strict'],
 		) => Promise<null | { id: string } | never>;
 
 		expiresIn?: number;

--- a/packages/medusa-plugin-auth/src/loaders/index.ts
+++ b/packages/medusa-plugin-auth/src/loaders/index.ts
@@ -8,6 +8,7 @@ import LinkedinStrategy from '../auth-strategies/linkedin';
 import FireaseStrategy from '../auth-strategies/firebase';
 import Auth0Strategy from '../auth-strategies/auth0';
 import AzureStrategy from '../auth-strategies/azure-oidc';
+import SteamStrategy from '../auth-strategies/steam';
 
 export default async function authStrategiesLoader(container: MedusaContainer, authOptions: AuthOptions) {
 	const configModule = container.resolve('configModule') as ConfigModule;
@@ -19,4 +20,5 @@ export default async function authStrategiesLoader(container: MedusaContainer, a
 	FireaseStrategy.load(container, configModule, authOptions);
 	Auth0Strategy.load(container, configModule, authOptions);
 	AzureStrategy.load(container, configModule, authOptions);
+	SteamStrategy.load(container, configModule, authOptions);
 }

--- a/packages/medusa-plugin-auth/src/types/index.ts
+++ b/packages/medusa-plugin-auth/src/types/index.ts
@@ -19,6 +19,7 @@ import {
 import { AUTH0_ADMIN_STRATEGY_NAME, AUTH0_STORE_STRATEGY_NAME, Auth0Options } from '../auth-strategies/auth0';
 import { AZURE_ADMIN_STRATEGY_NAME, AZURE_STORE_STRATEGY_NAME, AzureAuthOptions } from '../auth-strategies/azure-oidc';
 import { OAUTH2_ADMIN_STRATEGY_NAME, OAUTH2_STORE_STRATEGY_NAME, OAuth2AuthOptions } from '../auth-strategies/oauth2';
+import { STEAM_ADMIN_STRATEGY_NAME, STEAM_STORE_STRATEGY_NAME, SteamAuthOptions } from '../auth-strategies/steam';
 
 export const CUSTOMER_METADATA_KEY = 'useSocialAuth';
 export const AUTH_PROVIDER_KEY = 'authProvider';
@@ -52,6 +53,7 @@ export type ProviderOptions = {
 	auth0?: Auth0Options;
 	azure_oidc?: AzureAuthOptions;
 	oauth2?: OAuth2AuthOptions;
+	steam?: SteamAuthOptions;
 };
 
 export type StrategyErrorIdentifierType = keyof ProviderOptions;
@@ -90,5 +92,9 @@ export const strategyNames: StrategyNames = {
 	oauth2: {
 		admin: OAUTH2_ADMIN_STRATEGY_NAME,
 		store: OAUTH2_STORE_STRATEGY_NAME,
+	},
+	steam: {
+		admin: STEAM_ADMIN_STRATEGY_NAME,
+		store: STEAM_STORE_STRATEGY_NAME,
 	},
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4085,6 +4085,19 @@
     chrome-trace-event "^1.0.2"
     nullthrows "^1.1.1"
 
+"@passport-next/passport-openid@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@passport-next/passport-openid/-/passport-openid-1.0.0.tgz#d3b5e067a9aa1388ed172ab7cc02c39b8634283d"
+  integrity sha512-W9uj4Ui/ZK/iBUNzSNxPWDQ8wCD1tUddGEVSGm0FN0B7ewo3yBQLGMoW3i3UqcwEzxdyGbAj06ohAhNQIXC4VA==
+  dependencies:
+    "@passport-next/passport-strategy" "1.x.x"
+    openid "2.x.x"
+
+"@passport-next/passport-strategy@1.x.x":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@passport-next/passport-strategy/-/passport-strategy-1.1.0.tgz#4c0df069e2ec9262791b9ef1e23320c1d73bdb74"
+  integrity sha512-2KhFjtPueJG6xVj2HnqXt9BlANOfYCVLyu+pXYjPGBDT8yk+vQwc/6tsceIj+mayKcoxMau2JimggXRPHgoc8w==
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.7":
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.8.tgz#da3383761e2c0c440610819f3204769022a38d12"
@@ -5141,6 +5154,11 @@
     "@types/express" "*"
     "@types/oauth" "*"
     "@types/passport" "*"
+
+"@types/passport-steam@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@types/passport-steam/-/passport-steam-1.0.4.tgz#407ca7c7ad95dca500acb0b9184df5b58db73ca6"
+  integrity sha512-ce4qbKzjQylW54pVzgyq1p/E8PfOJcKcvp66VUKRk4sFSFjbZtTjQCaeSugJZ64iEiAyzhNo9UkusqvpK5DwgA==
 
 "@types/passport@*":
   version "1.0.16"
@@ -14649,6 +14667,14 @@ openapi-types@^12.0.2:
   resolved "https://registry.yarnpkg.com/openapi-types/-/openapi-types-12.0.2.tgz#b752ab0a463c594fd7e3142e0e5983a9645503f6"
   integrity sha512-GuTo7FyZjOIWVhIhQSWJVaws6A82sWIGyQogxxYBYKZ0NBdyP2CYSIgOwFfSB+UVoPExk/YzFpyYitHS8KVZtA==
 
+openid@2.x.x:
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/openid/-/openid-2.0.10.tgz#b611ee673dbefd9c8199f1e30ff3e75628b4a504"
+  integrity sha512-EFTQ61/OUVhCeq78Y3rBpdKSuvgb0lwkU8nN4QTdcv0afc5MT7e4IVuZwgkMsgE993dmhbIhkxHFP3iTVJXWmw==
+  dependencies:
+    axios "^0.21.4"
+    qs "^6.5.2"
+
 opentracing@^0.14.5:
   version "0.14.7"
   resolved "https://registry.yarnpkg.com/opentracing/-/opentracing-0.14.7.tgz#25d472bd0296dc0b64d7b94cbc995219031428f5"
@@ -15144,6 +15170,14 @@ passport-oauth@^1.0.0:
   dependencies:
     passport-oauth1 "1.x.x"
     passport-oauth2 "1.x.x"
+
+passport-steam@^1.0.18:
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/passport-steam/-/passport-steam-1.0.18.tgz#7d934344c521f04adb35628f7118761f502299d5"
+  integrity sha512-3S6XlgATcJE3M3IfpwkvjWHeTDreaPUWQPykwxjv8LA5RtnfHrkt5c5HJdadYMCRHf3qh1OfCWETMxdpSdlBZA==
+  dependencies:
+    "@passport-next/passport-openid" "^1.0.0"
+    steam-web "0.4.0"
 
 passport-strategy@1.x.x, passport-strategy@^1.0.0:
   version "1.0.0"
@@ -16015,7 +16049,7 @@ qs@6.9.3:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.3.tgz#bfadcd296c2d549f1dffa560619132c977f5008e"
   integrity sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==
 
-qs@^6.11.2:
+qs@^6.1.0, qs@^6.11.2, qs@^6.5.2:
   version "6.11.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
   integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
@@ -17458,6 +17492,13 @@ statuses@2.0.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+steam-web@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/steam-web/-/steam-web-0.4.0.tgz#9333b5843ff7ebd77945fe09a0d5d5b28694b331"
+  integrity sha512-FgSYhL7GaP4Va5JKT09yZ+WrTZttFtLwenIPuZd7GUA1z3W7vu7qqPT/qTC76Pd9+sf85txMgIPr/y0+3gNlUA==
+  dependencies:
+    qs "^6.1.0"
 
 stream-events@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
This is a pull request to add Steam support. But some limitations are to be listed:
- This can't work with admin: The current code find users by email & steam don't expose emails
- https://developer.valvesoftware.com/wiki/Steam_Web_API#GetPlayerSummaries_.28v0002.29
- https://steamid.pro/how-to-find-out-someones-steam-email#:~:text=Steam%20never%20discloses%20emails%20of,never%20trust%20third%20party%20services.