### PR TITLE
Feat: Custom userProfile for Oauth2 to support login with Keycloak; Include phone to customer when logging in store

### DIFF
--- a/docs/pages/authentication/oauth2.mdx
+++ b/docs/pages/authentication/oauth2.mdx
@@ -73,7 +73,37 @@ newly added plugins. To do so here are the steps
           // verifyCallback: (container, req, accessToken, refreshToken, profile, strict) => {
           //    // implement your custom verify callback here if you need it
           // }
-        }
+        },
+        // parseProfile: (json) => {
+        //   const profile = {
+        //     provider: "keycloak",
+        //     id: json.sub,
+        //     username: json.preferred_username,
+        //     displayName: json.name,
+        //     email: json.email,
+        //     name: {
+        //       familyName: json.family_name,
+        //       givenName: json.given_name,
+        //     },
+        //     emails: json.email
+        //       ? [
+        //           {
+        //             value: json.email,
+        //           },
+        //         ]
+        //       : [],
+        //     _json: json,
+        //     phoneNumbers: json.phone_number
+        //       ? [
+        //           {
+        //             value: json.phone_number ?? "",
+        //           },
+        //         ]
+        //       : [],
+        //   };
+
+        //   return profile;
+        // },
       }
     ]
   }

--- a/packages/medusa-plugin-auth/src/auth-strategies/oauth2/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/oauth2/admin.ts
@@ -51,6 +51,23 @@ export function getOAuth2AdminStrategy(id: string): StrategyFactory<OAuth2AuthOp
 				strategyName,
 			});
 		}
+
+		userProfile(accessToken, done: (err: any, profile?: any) => void) {
+			if (this.strategyOptions.parseProfile !== undefined) {
+				let json;
+
+				try {
+					json = JSON.parse(Buffer.from(accessToken.split('.')[1], 'base64').toString());
+				} catch (ex) {
+					return done(new Error('Failed to parse access token'));
+				}
+
+				const profile = this.strategyOptions.parseProfile(json);
+				done(null, profile);
+			} else {
+				super.userProfile(accessToken, done);
+			}
+		}
 	};
 }
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/oauth2/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/oauth2/store.ts
@@ -51,6 +51,23 @@ export function getOAuth2StoreStrategy(id: string): StrategyFactory<OAuth2AuthOp
 				strategyName,
 			});
 		}
+
+		userProfile(accessToken, done: (err: any, profile?: any) => void) {
+			if (this.strategyOptions.parseProfile !== undefined) {
+				let json;
+
+				try {
+					json = JSON.parse(Buffer.from(accessToken.split('.')[1], 'base64').toString());
+				} catch (ex) {
+					return done(new Error('Failed to parse access token'));
+				}
+
+				const profile = this.strategyOptions.parseProfile(json);
+				done(null, profile);
+			} else {
+				super.userProfile(accessToken, done);
+			}
+		}
 	};
 }
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/oauth2/types.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/oauth2/types.ts
@@ -65,4 +65,5 @@ export type OAuth2AuthOptions = {
 		expiresIn?: number;
 	};
 	scope?: string[];
+	parseProfile?: (profile: any) => any;
 };

--- a/packages/medusa-plugin-auth/src/core/validate-callback.ts
+++ b/packages/medusa-plugin-auth/src/core/validate-callback.ts
@@ -81,6 +81,7 @@ export async function validateStoreCallback<
 			email_verified?: boolean;
 		};
 		emails?: { value: string }[];
+		phoneNumbers?: { value: string }[];
 	} = {
 		emails?: { value: string }[];
 	}
@@ -173,6 +174,7 @@ export async function validateStoreCallback<
 			last_name: profile.name?.familyName ?? '',
 			has_account: true,
 			password: generatePassword(),
+			phone: profile.phoneNumbers?.[0]?.value ?? '',
 		});
 
 		return { id: customer.id };


### PR DESCRIPTION
Currently, Oauth2 is allowing user to login with keycloak, but the generated profile returned by Keycloak doesn't follow the [Oauth2 User Profile](https://www.passportjs.org/reference/normalized-profile/) format so it returns `Your oauth2 account does not contains any email and cannot be used` error.
With this change, we can pass an optional option to `oauth2` named `parseProfile` which should return a normalized json profile that follows the [Oauth2 User Profile](https://www.passportjs.org/reference/normalized-profile/) format

```js
{
    resolve: "medusa-plugin-auth",
    /** @type {import('medusa-plugin-auth').AuthOptions} */
    options: [
      {
        type: "oauth2",
        strict: "none",
        // or "none" or "store" or "admin"
        identifier: "oauth2",
        authorizationURL: OAuth2AuthorizationURL,
        tokenURL: OAuth2TokenURL,
        clientID: OAuth2ClientId,
        clientSecret: OAuth2ClientSecret,
        scope: OAuth2Scope.split(","),
        admin: {
          callbackUrl: `${BACKEND_URL}/admin/auth/oauth2/cb`,
          failureRedirect: `${ADMIN_URL}/login`,
          successRedirect: `${ADMIN_URL}/`,
        },
        store: {
          callbackUrl: `${BACKEND_URL}/store/auth/oauth2/cb`,
          failureRedirect: `${STORE_URL}/login`,
          successRedirect: `${STORE_URL}/`,
        },
        parseProfile: (json) => {
          const profile = {
            provider: "keycloak",
            id: json.sub,
            username: json.preferred_username,
            displayName: json.name,
            email: json.email,
            name: {
              familyName: json.family_name,
              givenName: json.given_name,
            },
            emails: json.email
              ? [
                  {
                    value: json.email,
                  },
                ]
              : [],
            _json: json,
            phoneNumbers: json.phone_number
              ? [
                  {
                    value: json.phone_number ?? "",
                  },
                ]
              : [],
          };

          return profile;
        },
      },
    ],
  }
```