### PR TITLE
fix: scope parameter from medusa-config.js not passed through to passport

### DIFF
--- a/packages/medusa-plugin-auth/package.json
+++ b/packages/medusa-plugin-auth/package.json
@@ -1,113 +1,113 @@
 {
-  "name": "medusa-plugin-auth",
-  "version": "1.11.1",
-  "description": "Social authentication plugin for medusajs 1.x",
-  "keywords": [
-    "social",
-    "auth",
-    "auth0",
-    "google",
-    "google+",
-    "facebook",
-    "twitter",
-    "linkedin",
-    "github",
-    "microsoft",
-    "passportjs",
-    "oauth2",
-    "medusa",
-    "medusajs",
-    "e-commerce",
-    "authentication",
-    "medusa-plugins",
-    "medusa-plugin"
-  ],
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/adrien2p/medusa-plugins.git"
-  },
-  "author": "Adrien de Peretti <adrien.deperetti@gmail.com",
-  "files": [
-    "api",
-    "utils",
-    "core",
-    "types",
-    "loaders",
-    "auth-strategies"
-  ],
-  "types": "types/index.d.ts",
-  "scripts": {
-    "build": "run-s clean build:tsc",
-    "build:tsc:watch": "tsc --build ./tsconfig.json --watch",
-    "build:tsc": "tsc -b",
-    "clean": "rimraf api services utils types loaders auth-strategies coverage tsconfig.tsbuildinfo",
-    "test": "jest",
-    "test:ci": "yarn add -D @medusajs/medusa@${MEDUSAJS_VERSION} && yarn run test"
-  },
-  "peerDependencies": {
-    "@medusajs/medusa": ">=1.16.x",
-    "passport": "^0.6.0",
-    "typeorm": "*"
-  },
-  "devDependencies": {
-    "@medusajs/medusa": ">=1.17.x",
-    "@types/express": "^4.17.17",
-    "@types/jest": "^29.1.2",
-    "@types/passport-auth0": "^1.0.9",
-    "@types/passport-azure-ad": "^4.3.5",
-    "@types/passport-facebook": "^3.0.3",
-    "@types/passport-google-oauth2": "^0.1.8",
-    "@types/passport-linkedin-oauth2": "^1.5.6",
-    "@types/passport-oauth2": "^1.4.15",
-    "jest": "^29.1.2",
-    "passport": "^0.6.0",
-    "ts-jest": "^29.0.3",
-    "ts-node": "^8.6.2",
-    "typeorm": "^0.3.15"
-  },
-  "dependencies": {
-    "@superfaceai/passport-twitter-oauth2": "^1.1.0",
-    "@types/node": "^18.11.10",
-    "cors": "^2.8.5",
-    "express": "^4.18.1",
-    "firebase-admin": "^11.4.1",
-    "jsonwebtoken": "^8.5.1",
-    "passport-auth0": "^1.4.3",
-    "passport-azure-ad": "^4.3.5",
-    "passport-facebook": "^3.0.0",
-    "passport-firebase-jwt": "^1.2.1",
-    "passport-google-oauth2": "^0.2.0",
-    "passport-linkedin-oauth2": "^2.0.0",
-    "passport-oauth2": "^1.7.0",
-    "tldjs": "^2.3.1"
-  },
-  "jest": {
-    "preset": "ts-jest",
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
+    "name": "medusa-plugin-auth",
+    "version": "1.11.1",
+    "description": "Social authentication plugin for medusajs 1.x",
+    "keywords": [
+        "social",
+        "auth",
+        "auth0",
+        "google",
+        "google+",
+        "facebook",
+        "twitter",
+        "linkedin",
+        "github",
+        "microsoft",
+        "passportjs",
+        "oauth2",
+        "medusa",
+        "medusajs",
+        "e-commerce",
+        "authentication",
+        "medusa-plugins",
+        "medusa-plugin"
     ],
-    "testTimeout": 100000,
-    "rootDir": "src",
-    "testRegex": ".*\\.spec\\.ts$",
-    "transformIgnorePatterns": [
-      "/node_modules/"
+    "license": "MIT",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/adrien2p/medusa-plugins.git"
+    },
+    "author": "Adrien de Peretti <adrien.deperetti@gmail.com",
+    "files": [
+        "api",
+        "utils",
+        "core",
+        "types",
+        "loaders",
+        "auth-strategies"
     ],
-    "collectCoverageFrom": [
-      "**/*.(t|j)s",
-      "!**/__*__/*.(t|j)s"
-    ],
-    "coverageReporters": [
-      "json-summary",
-      "text",
-      "lcov"
-    ],
-    "coverageDirectory": "<rootDir>/../coverage",
-    "testEnvironment": "node",
-    "setupFilesAfterEnv": [
-      "<rootDir>/../setup-tests.js"
-    ]
-  }
+    "types": "types/index.d.ts",
+    "scripts": {
+        "build": "run-s clean build:tsc",
+        "build:tsc:watch": "tsc --build ./tsconfig.json --watch",
+        "build:tsc": "tsc -b",
+        "clean": "rimraf api services utils types loaders auth-strategies coverage tsconfig.tsbuildinfo",
+        "test": "jest",
+        "test:ci": "yarn add -D @medusajs/medusa@${MEDUSAJS_VERSION} && yarn run test"
+    },
+    "peerDependencies": {
+        "@medusajs/medusa": ">=1.16.x",
+        "passport": "^0.6.0",
+        "typeorm": "*"
+    },
+    "devDependencies": {
+        "@medusajs/medusa": ">=1.17.x",
+        "@types/express": "^4.17.17",
+        "@types/jest": "^29.1.2",
+        "@types/passport-auth0": "^1.0.9",
+        "@types/passport-azure-ad": "^4.3.5",
+        "@types/passport-facebook": "^3.0.3",
+        "@types/passport-google-oauth2": "^0.1.8",
+        "@types/passport-linkedin-oauth2": "^1.5.6",
+        "@types/passport-oauth2": "^1.4.15",
+        "jest": "^29.1.2",
+        "passport": "^0.6.0",
+        "ts-jest": "^29.0.3",
+        "ts-node": "^8.6.2",
+        "typeorm": "^0.3.15"
+    },
+    "dependencies": {
+        "@superfaceai/passport-twitter-oauth2": "^1.1.0",
+        "@types/node": "^18.11.10",
+        "cors": "^2.8.5",
+        "express": "^4.18.1",
+        "firebase-admin": "^11.4.1",
+        "jsonwebtoken": "^8.5.1",
+        "passport-auth0": "^1.4.3",
+        "passport-azure-ad": "^4.3.5",
+        "passport-facebook": "^3.0.0",
+        "passport-firebase-jwt": "^1.2.1",
+        "passport-google-oauth2": "^0.2.0",
+        "passport-linkedin-oauth2": "^2.0.0",
+        "passport-oauth2": "^1.7.0",
+        "tldjs": "^2.3.1"
+    },
+    "jest": {
+        "preset": "ts-jest",
+        "moduleFileExtensions": [
+            "js",
+            "json",
+            "ts"
+        ],
+        "testTimeout": 100000,
+        "rootDir": "src",
+        "testRegex": ".*\\.spec\\.ts$",
+        "transformIgnorePatterns": [
+            "/node_modules/"
+        ],
+        "collectCoverageFrom": [
+            "**/*.(t|j)s",
+            "!**/__*__/*.(t|j)s"
+        ],
+        "coverageReporters": [
+            "json-summary",
+            "text",
+            "lcov"
+        ],
+        "coverageDirectory": "<rootDir>/../coverage",
+        "testEnvironment": "node",
+        "setupFilesAfterEnv": [
+            "<rootDir>/../setup-tests.js"
+        ]
+    }
 }

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/admin.ts
@@ -32,6 +32,7 @@ export function getAzureAdminStrategy(id: string): StrategyFactory<AzureAuthOpti
 				isB2C: strategyOptions.admin.isB2C ?? false,
 				issuer: strategyOptions.admin.issuer,
 				passReqToCallback: true,
+				scope: strategyOptions.admin.scope
 			} as IOIDCStrategyOptionWithRequest);
 		}
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
@@ -33,6 +33,7 @@ export function getAzureStoreStrategy(id: string): StrategyFactory<AzureAuthOpti
 				isB2C: strategyOptions.store.isB2C ?? false,
 				issuer: strategyOptions.store.issuer,
 				passReqToCallback: true,
+				scope: strategyOptions.store.scope
 			} as IOIDCStrategyOptionWithRequest);
 		}
 


### PR DESCRIPTION
I had to extend the scope of the token request to Microsoft Entra in order to receive the claims that I needed.

For that, setting the scope parameter in the passportAuthenticateMiddlewareOptions was not enough, since passport (at least for version 0.6.0) determines the scope from the argument "options" passed to the constructor of the strategy.

I hope you are fine with me bumping the version and writing to the changelog. I'm sorry if you're not. It's my first pull request.