### PR TITLE
fix: admin.scope and store.scope parameters from medusa-config.js not passed through to passport

### DIFF
--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/admin.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/admin.ts
@@ -32,6 +32,7 @@ export function getAzureAdminStrategy(id: string): StrategyFactory<AzureAuthOpti
 				isB2C: strategyOptions.admin.isB2C ?? false,
 				issuer: strategyOptions.admin.issuer,
 				passReqToCallback: true,
+				scope: strategyOptions.admin.scope,
 			} as IOIDCStrategyOptionWithRequest);
 		}
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
@@ -33,6 +33,7 @@ export function getAzureStoreStrategy(id: string): StrategyFactory<AzureAuthOpti
 				isB2C: strategyOptions.store.isB2C ?? false,
 				issuer: strategyOptions.store.issuer,
 				passReqToCallback: true,
+				scope: strategyOptions.admin.scope,
 			} as IOIDCStrategyOptionWithRequest);
 		}
 

--- a/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
+++ b/packages/medusa-plugin-auth/src/auth-strategies/azure-oidc/store.ts
@@ -33,7 +33,7 @@ export function getAzureStoreStrategy(id: string): StrategyFactory<AzureAuthOpti
 				isB2C: strategyOptions.store.isB2C ?? false,
 				issuer: strategyOptions.store.issuer,
 				passReqToCallback: true,
-				scope: strategyOptions.admin.scope,
+				scope: strategyOptions.store.scope,
 			} as IOIDCStrategyOptionWithRequest);
 		}
 


### PR DESCRIPTION
Hi Adrien,

I created this pull request as I messed up rolling back the changes to CHANGELOG.md and package.json. I'm sorry.

I had to extend the scope of the token request to Microsoft Entra in order to receive the claims that I needed.
For that, setting the scope parameter in the passportAuthenticateMiddlewareOptions was not enough, since passport (at least for version 0.6.0) determines the scope from the argument "options" passed to the constructor of the strategy.

Best regards,
Fredrik